### PR TITLE
fix(launch): emit --flash-attn on|off, parser absorbs tri-state value

### DIFF
--- a/src/cli/tail_args.rs
+++ b/src/cli/tail_args.rs
@@ -29,14 +29,32 @@ pub fn parse_tail_args(tokens: &[OsString]) -> Result<(TypedKnobs, Vec<OsString>
     match recognised {
       Some((field, kind, inline)) => {
         let value = match kind {
-          // Booleans default to `Some(true)` when the user supplies a
-          // bare flag (`--flash-attn`). The equals-form
-          // (`--flash-attn=false`) is honoured so users can override a
-          // built-in `Some(true)` to `Some(false)` without having to
-          // edit YAML or use the TUI. Space-form (`--flash-attn false`)
-          // is *not* consumed — the next token is left for normal
-          // parsing, matching the bare-flag convention of llama-server.
-          ValueKind::Bool => inline.clone(),
+          // Booleans default to `Some(true)` for a bare flag
+          // (`--flash-attn`). The equals-form (`--flash-attn=false`)
+          // is honoured so a user override actually disables a knob
+          // an inherited layer set to `true`. Space-form is consumed
+          // only when the next token is a recognised on/off spelling
+          // — upstream llama.cpp PR #15434 (merged 2025-08-30,
+          // first in tag b6325) made `--flash-attn` tri-state
+          // requiring `on|off|auto`, so we mirror the new syntax
+          // here. Anything else stays unconsumed and routes through
+          // extras like before.
+          ValueKind::Bool => {
+            if let Some(v) = inline.clone() {
+              Some(v)
+            } else {
+              match iter
+                .peek()
+                .map(|t| t.to_string_lossy().to_ascii_lowercase())
+              {
+                Some(p) if is_bool_value_token(&p) => {
+                  iter.next();
+                  Some(p)
+                }
+                _ => None,
+              }
+            }
+          }
           _ => Some(consume_value(&lossy, inline.as_deref(), &mut iter)?),
         };
         apply_knob(&mut knobs, field, kind, value.as_deref(), &lossy)?;
@@ -45,6 +63,19 @@ pub fn parse_tail_args(tokens: &[OsString]) -> Result<(TypedKnobs, Vec<OsString>
     }
   }
   Ok((knobs, extras))
+}
+
+/// `parse_bool`-spellings that may follow a bool flag in space form,
+/// matching the `on|off|true|false|...` spellings `parse_bool` accepts.
+/// `auto` (llama-server's tri-state default for `--flash-attn`) is
+/// intentionally NOT consumed — the bench never uses it and consuming
+/// it would force `parse_bool` to invent a meaning. A user passing
+/// `--flash-attn auto` instead routes `auto` to extras unchanged.
+fn is_bool_value_token(s: &str) -> bool {
+  matches!(
+    s,
+    "on" | "off" | "true" | "false" | "1" | "0" | "yes" | "no"
+  )
 }
 
 fn consume_value<'a, I>(
@@ -230,6 +261,33 @@ mod tests {
     let (knobs, _) = parse_tail_args(&osvec(&["--flash-attn", "--threads", "8"])).unwrap();
     assert_eq!(knobs.flash_attn, Some(true));
     assert_eq!(knobs.threads, Some(8));
+  }
+
+  #[test]
+  fn boolean_space_form_consumes_on_off_value() {
+    // Upstream llama.cpp PR #15434 (first in tag b6325, 2025-08-30)
+    // made `--flash-attn` tri-state: the user's space-form value
+    // must be absorbed rather than left as an orphan positional that
+    // llama-server then rejects.
+    let (knobs_on, extras_on) = parse_tail_args(&osvec(&["--flash-attn", "on"])).unwrap();
+    assert_eq!(knobs_on.flash_attn, Some(true));
+    assert!(
+      extras_on.is_empty(),
+      "`on` must be consumed, not routed to extras: {extras_on:?}"
+    );
+
+    let (knobs_off, extras_off) = parse_tail_args(&osvec(&["--flash-attn", "off"])).unwrap();
+    assert_eq!(knobs_off.flash_attn, Some(false));
+    assert!(extras_off.is_empty());
+  }
+
+  #[test]
+  fn boolean_space_form_leaves_auto_to_extras() {
+    // `auto` isn't a parse_bool spelling — pass it through to the
+    // child via extras so llama-server can interpret it natively.
+    let (knobs, extras) = parse_tail_args(&osvec(&["--flash-attn", "auto"])).unwrap();
+    assert_eq!(knobs.flash_attn, Some(true));
+    assert_eq!(extras, vec![OsString::from("auto")]);
   }
 
   #[test]

--- a/src/launch/params.rs
+++ b/src/launch/params.rs
@@ -605,7 +605,10 @@ mod tests {
       ..TypedKnobs::default()
     };
     let argv = strs(&argvify(&knobs));
-    assert!(argv.is_empty(), "Some(false) bare bools must not emit the flag");
+    assert!(
+      argv.is_empty(),
+      "Some(false) bare bools must not emit the flag"
+    );
   }
 
   #[test]

--- a/src/launch/params.rs
+++ b/src/launch/params.rs
@@ -202,7 +202,7 @@ pub fn argvify(knobs: &TypedKnobs) -> Vec<OsString> {
       KnobField::CacheTypeK => push_str(&mut out, spec.canonical, knobs.cache_type_k.as_deref()),
       KnobField::CacheTypeV => push_str(&mut out, spec.canonical, knobs.cache_type_v.as_deref()),
       KnobField::Parallel => push_u32(&mut out, spec.canonical, knobs.parallel),
-      KnobField::FlashAttn => push_bool(&mut out, spec.canonical, knobs.flash_attn),
+      KnobField::FlashAttn => push_flash_attn(&mut out, spec.canonical, knobs.flash_attn),
       KnobField::Mlock => push_bool(&mut out, spec.canonical, knobs.mlock),
       KnobField::NoMmap => push_bool(&mut out, spec.canonical, knobs.no_mmap),
       KnobField::BatchSize => push_u32(&mut out, spec.canonical, knobs.batch_size),
@@ -247,6 +247,28 @@ fn push_str(out: &mut Vec<OsString>, canonical: &str, value: Option<&str>) {
 fn push_bool(out: &mut Vec<OsString>, canonical: &str, value: Option<bool>) {
   if value == Some(true) {
     out.push(canonical.into());
+  }
+}
+
+/// Upstream llama.cpp [PR #15434](https://github.com/ggml-org/llama.cpp/pull/15434)
+/// (merged 2025-08-30, first in tag **b6325**) made `--flash-attn`
+/// a tri-state argument requiring `on|off|auto` and defaulted it to
+/// `auto`. Any `llama-server` >= b6325 rejects the bare flag —
+/// passing `--flash-attn` alone causes the next argv entry to be
+/// parsed as the flash-attn value. We always emit the explicit
+/// `on`/`off` form so a user-level `Some(false)` actually disables
+/// an inherited `Some(true)` rather than silently dropping.
+fn push_flash_attn(out: &mut Vec<OsString>, canonical: &str, value: Option<bool>) {
+  match value {
+    Some(true) => {
+      out.push(canonical.into());
+      out.push("on".into());
+    }
+    Some(false) => {
+      out.push(canonical.into());
+      out.push("off".into());
+    }
+    None => {}
   }
 }
 
@@ -547,6 +569,7 @@ mod tests {
         "--parallel",
         "4",
         "--flash-attn",
+        "on",
         "--mlock",
         "--no-mmap",
         "--batch-size",
@@ -569,18 +592,33 @@ mod tests {
       ..TypedKnobs::default()
     };
     let argv = strs(&argvify(&knobs));
-    assert_eq!(argv, vec!["--n-gpu-layers", "99", "--flash-attn"]);
+    assert_eq!(argv, vec!["--n-gpu-layers", "99", "--flash-attn", "on"]);
   }
 
   #[test]
-  fn argvify_some_false_omits_boolean_flag() {
+  fn argvify_some_false_omits_bare_bool_flags() {
+    // True bare flags (`--mlock`, `--no-mmap`) are absent when set to
+    // false — there's no `--no-mlock` form in llama-server.
     let knobs = TypedKnobs {
-      flash_attn: Some(false),
       mlock: Some(false),
+      no_mmap: Some(false),
       ..TypedKnobs::default()
     };
     let argv = strs(&argvify(&knobs));
-    assert!(argv.is_empty(), "Some(false) bools must not emit the flag");
+    assert!(argv.is_empty(), "Some(false) bare bools must not emit the flag");
+  }
+
+  #[test]
+  fn argvify_flash_attn_false_emits_off() {
+    // `--flash-attn` takes a value (`on|off|auto`); Some(false) MUST
+    // emit `--flash-attn off` so a user override actually disables it
+    // when an inherited layer set Some(true).
+    let knobs = TypedKnobs {
+      flash_attn: Some(false),
+      ..TypedKnobs::default()
+    };
+    let argv = strs(&argvify(&knobs));
+    assert_eq!(argv, vec!["--flash-attn", "off"]);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Upstream llama.cpp [PR #15434](https://github.com/ggml-org/llama.cpp/pull/15434) (merged 2025-08-30, first in tag **b6325**) made `--flash-attn` a tri-state argument requiring `on|off|auto` and defaulted it to `auto`. Any `llama-server` ≥ b6325 rejects the bare flag — passing `--flash-attn` alone causes the next argv entry to be parsed as the flash-attn value.

Two production code paths in the launcher emitted/parsed the bare-flag form and would silently break a `llamastash start` against any modern llama-server build with a launch failure like:

```
error while handling argument "--flash-attn":
error: unknown value for --flash-attn: '--cache-type-k'
```

The model spawn timed out at the supervisor's readiness check with no surface error; users would see a 3-minute hang ending in "model failed to start" with the actual cause buried in `~/.cache/llamastash/logs/<model>-*.log`.

## Changes

1. **`src/launch/params.rs::argvify()`** — was emitting `--flash-attn` bare when `knobs.flash_attn == Some(true)`. New `push_flash_attn` helper emits the explicit `--flash-attn on|off` form. The `Some(false)` path now emits `--flash-attn off` (instead of omitting the flag) so a user-level override actually disables an inherited `Some(true)` rather than silently dropping.

2. **`src/cli/tail_args.rs::parse_tail_args()`** — treated `--flash-attn` as a bare bool. When a user invoked `llamastash start <model> -- --flash-attn on`, the parser took only the flag and routed `on` to extras as an orphan positional that llama-server then rejected. New behavior: when a `ValueKind::Bool` knob is followed by an `on|off|true|false|1|0|yes|no` token, the parser consumes it (matching the new llama-server syntax). `auto` is intentionally left in extras since `parse_bool` has no tri-state semantic for it.

The existing `--flash-attn=on` equals-form keeps working unchanged.

## Test plan

- [x] `cargo test --lib -p llamastash launch::params` (25 pass — includes split of `argvify_some_false_omits_boolean_flag` into the bare-bool case and the new `argvify_flash_attn_false_emits_off`)
- [x] `cargo test --lib -p llamastash cli::tail_args` (18 pass — includes new `boolean_space_form_consumes_on_off_value` and `boolean_space_form_leaves_auto_to_extras`)
- [x] Full lib test suite: 1247 pass
- [x] `cargo clippy --all-targets --features test-fixtures -- -D warnings` clean
- [x] Manually verified end-to-end: `llamastash start <model> --port <N> -- --flash-attn on --cache-type-k f16 --cache-type-v f16` now spawns successfully on a `llama-server` from llama.cpp b9282 (HIP build, gfx1151). Before this fix, the same invocation produced the "unknown value for --flash-attn" error from llama-server's stderr.

## Why peeled out

Discovered while building out a benchmark harness (separate WIP branch) that drives `llamastash start` with normalized knob sets across model sizes. Every normalized cell failed with the readiness timeout above. Root-cause turned out to be a real production-side bug in the launcher that affects any user who passes `--flash-attn` with a `llama-server` ≥ b6325, not just the bench harness. Peeling it out so it can merge ahead of the (larger) bench harness PR.