### PR TITLE
feat: find and load mmproj ggufs that are stored alongside models

### DIFF
--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -8,10 +8,11 @@
 //! starve the runtime when the user has hundreds of GGUFs on disk.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use futures::stream::{self, StreamExt};
 use ignore::WalkBuilder;
+use regex::Regex;
 use tokio::sync::mpsc;
 
 use crate::discovery::metadata_cache::{self, CachedParse, MetadataCache};
@@ -125,38 +126,139 @@ fn is_projector_companion(path: &Path) -> bool {
   path
     .file_name()
     .and_then(|n| n.to_str())
-    .map(|n| n.starts_with("mmproj-") || n.starts_with("mmproj_"))
+    .map(|n| {
+      let n = n.to_lowercase();
+      n.starts_with("mmproj-")
+        || n.starts_with("mmproj_")
+        || n.contains(".mmproj.")
+        || n.ends_with(".mmproj.gguf")
+        || n.ends_with("-mmproj.gguf")
+        || n.ends_with("_mmproj.gguf")
+        || n == "mmproj.gguf"
+    })
     .unwrap_or(false)
+}
+
+const QUANT_PATTERN: &str = r"\b(bf16|f16|f32|mxfp4_moe|iq[1-4](_?s|_?xs|_?xxs|_?m|_?nl|_?nl_xl)?|q[2-8](_?[01])?(_?k)?(_?[sml]|_?xl)?)\b";
+
+/// Strip all quantization tokens and separators from a name to derive
+/// a canonical base name for matching.
+fn canonical_base(s: &str) -> String {
+  static RE_QUANT: OnceLock<Regex> = OnceLock::new();
+  let re = RE_QUANT.get_or_init(|| Regex::new(QUANT_PATTERN).unwrap());
+
+  let mut s = s.to_lowercase();
+
+  // Strip all quantization tokens. We loop because multiple tokens
+  // might exist (rare but possible).
+  while let Some(m) = re.find(&s) {
+    let start = m.start();
+    let end = m.end();
+    s.replace_range(start..end, "");
+  }
+
+  // Clean up separators and common "UD" (Up/Down) markers
+  s.trim_matches(|c| c == '.' || c == '-' || c == '_')
+    .replace("-ud", "")
+    .replace(".ud", "")
+    .replace("_ud", "")
+    .trim_matches(|c| c == '.' || c == '-' || c == '_')
+    .to_string()
+}
+
+/// Strip mmproj-related prefixes and suffixes to find the base model
+/// name part.
+fn strip_mmproj_markers(name: &str) -> String {
+  let name = name.strip_suffix(".gguf").unwrap_or(name);
+  let mut s = name.to_lowercase();
+
+  if s.starts_with("mmproj-") {
+    s = s["mmproj-".len()..].to_string();
+  } else if s.starts_with("mmproj_") {
+    s = s["mmproj_".len()..].to_string();
+  }
+
+  if s.ends_with("-mmproj") {
+    s = s[..s.len() - "-mmproj".len()].to_string();
+  } else if s.ends_with("_mmproj") {
+    s = s[..s.len() - "_mmproj".len()].to_string();
+  } else if s.contains(".mmproj.") {
+    s = s.replace(".mmproj.", ".");
+  } else if s.ends_with(".mmproj") {
+    s = s[..s.len() - ".mmproj".len()].to_string();
+  }
+
+  if s == "mmproj" {
+    return "".to_string();
+  }
+
+  s
 }
 
 /// Find the multimodal projector (mmproj) companion file for a given
 /// model path. The projector file is expected to be in the same
-/// directory with a `mmproj-<stem>.gguf` or `mmproj_<stem>.gguf`
-/// naming pattern, where `<stem>` is the model's file name without the
-/// `.gguf` extension. Returns `None` if no companion is found.
+/// directory.
+///
+/// Matching ignores quantization labels in both filenames. A projector
+/// is matched if:
+/// 1. Its base name matches the model's base name.
+/// 2. It is an "anonymous" projector (e.g., `mmproj-f16.gguf` or
+///    `mmproj.gguf`), which serves as a fallback for any model in the
+///    same directory.
 pub fn find_mmproj(model_path: &Path) -> Option<PathBuf> {
   let parent = model_path.parent()?;
-  let stem = model_path.file_stem()?.to_str()?;
+  let model_filename = model_path.file_name()?.to_str()?;
+  let model_stem = model_path.file_stem()?.to_str()?;
+
+  let model_base = canonical_base(model_stem);
+
+  let mut candidates = Vec::new();
+  let mut anonymous_found = Vec::new();
+
   for entry in std::fs::read_dir(parent).ok()? {
-    let entry = entry.ok()?;
-    let name = entry.file_name();
-    let name_str = name.to_str()?;
-    let is_mmproj = name_str.starts_with("mmproj-") || name_str.starts_with("mmproj_");
-    if !is_mmproj {
+    let Ok(entry) = entry else {
+      continue;
+    };
+    let path = entry.path();
+    if !path.is_file() {
       continue;
     }
-    if let Some(rest) = name_str.strip_prefix("mmproj-") {
-      if rest == format!("{stem}.gguf") || rest == stem {
-        return Some(entry.path());
-      }
+
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+      continue;
+    };
+    if name == model_filename || !is_projector_companion(&path) {
+      continue;
     }
-    if let Some(rest) = name_str.strip_prefix("mmproj_") {
-      if rest == format!("{stem}.gguf") || rest == stem {
-        return Some(entry.path());
-      }
+
+    let stripped_name = strip_mmproj_markers(name);
+    let proj_base = canonical_base(&stripped_name);
+
+    if !proj_base.is_empty() && proj_base == model_base {
+      // 1. Direct base-name match
+      candidates.push((100, path));
+    } else if proj_base.is_empty() {
+      // 2. Anonymous/Generic fallback
+      anonymous_found.push(path.clone());
+      candidates.push((10, path));
     }
   }
-  None
+
+  if anonymous_found.len() > 1 {
+    log::warn!(
+      "multiple anonymous mmproj files found in {}; ignoring fallbacks for {} to avoid ambiguity: {:?}",
+      parent.display(),
+      model_filename,
+      anonymous_found
+        .iter()
+        .map(|p| p.file_name().unwrap().to_string_lossy())
+        .collect::<Vec<_>>()
+    );
+    candidates.retain(|(score, _)| *score >= 100);
+  }
+
+  candidates.sort_by(|a, b| b.0.cmp(&a.0));
+  candidates.into_iter().next().map(|(_, p)| p)
 }
 
 /// Concurrency cap for [`walk_root`]'s per-file parse. Default to
@@ -417,6 +519,16 @@ mod tests {
     .unwrap();
     fs::write(
       dir.join("mmproj_model_v2.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join("model.mmproj.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join("mmproj-BF16.gguf"),
       build_minimal_gguf("llama"),
     )
     .unwrap();
@@ -736,27 +848,135 @@ mod tests {
   }
 
   #[test]
-  fn find_mmproj_detects_mmproj_underscore_prefix() {
-    let dir = temp_dir("mmproj-find-underscore");
+  fn find_mmproj_detects_various_patterns() {
+    let dir = temp_dir("mmproj-patterns");
+    let model = "my-model";
+    fs::write(dir.join(format!("{model}.gguf")), build_minimal_gguf("llama")).unwrap();
+
+    let patterns = [
+      format!("mmproj_{model}.gguf"),
+      format!("{model}.mmproj.gguf"),
+      format!("{model}-mmproj.gguf"),
+      format!("{model}_mmproj.gguf"),
+    ];
+
+    for p in patterns {
+      fs::write(dir.join(&p), build_minimal_gguf("llama")).unwrap();
+      let found = find_mmproj(&dir.join(format!("{model}.gguf")));
+      assert!(found.is_some(), "failed to find {p}");
+      assert_eq!(
+        found.unwrap().file_name().and_then(|s| s.to_str()),
+        Some(p.as_str())
+      );
+      fs::remove_file(dir.join(&p)).unwrap();
+    }
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_handles_quants() {
+    let dir = temp_dir("mmproj-quants");
+    // Model with quant
     fs::write(
-      dir.join("Qwen2.5-7B.Q4_K_M.gguf"),
+      dir.join("Qwen2-7B-Q4_K_M.gguf"),
       build_minimal_gguf("llama"),
     )
     .unwrap();
+
+    // Matching projector with quant
     fs::write(
-      dir.join("mmproj_Qwen2.5-7B.Q4_K_M.gguf"),
+      dir.join("mmproj-Qwen2-7B-Q4_K_M.gguf"),
       build_minimal_gguf("llama"),
     )
     .unwrap();
-    let found = find_mmproj(&dir.join("Qwen2.5-7B.Q4_K_M.gguf"));
+
+    let found = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("mmproj-Qwen2-7B-Q4_K_M.gguf")
+    );
+
+    // Projector with different separator and quant
+    fs::remove_file(dir.join("mmproj-Qwen2-7B-Q4_K_M.gguf")).unwrap();
+    fs::write(
+      dir.join("Qwen2-7B.mmproj.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    let found = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("Qwen2-7B.mmproj.gguf")
+    );
+
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_handles_unsloth_style_quants() {
+    let dir = temp_dir("mmproj-unsloth");
+    fs::write(dir.join("model-Q4_K_M.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj-BF16.gguf"), build_minimal_gguf("llama")).unwrap();
+
+    let found = find_mmproj(&dir.join("model-Q4_K_M.gguf"));
     assert!(
       found.is_some(),
-      "find_mmproj must find mmproj_Qwen2.5-7B.Q4_K_M.gguf"
+      "should match mmproj-BF16 to Q4_K_M model as fallback"
+    );
+
+    fs::remove_file(dir.join("mmproj-BF16.gguf")).unwrap();
+    fs::write(dir.join("mmproj-Q4_K_M.gguf"), build_minimal_gguf("llama")).unwrap();
+    let found = find_mmproj(&dir.join("model-Q4_K_M.gguf"));
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("mmproj-Q4_K_M.gguf"),
+      "anonymous match should work when only one exists"
+    );
+
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_handles_unsloth_mismatched_quants_when_single() {
+    let dir = temp_dir("mmproj-unsloth-mismatch");
+    fs::write(dir.join("mimi-0.1.Q4_K_M.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj-f16.gguf"), build_minimal_gguf("llama")).unwrap();
+
+    let found = find_mmproj(&dir.join("mimi-0.1.Q4_K_M.gguf"));
+    assert!(
+      found.is_some(),
+      "should find mmproj-f16.gguf even if model is Q4_K_M when it's the only projector"
     );
     assert_eq!(
       found.unwrap().file_name().and_then(|s| s.to_str()),
-      Some("mmproj_Qwen2.5-7B.Q4_K_M.gguf")
+      Some("mmproj-f16.gguf")
     );
+
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_ignores_ambiguous_anonymous() {
+    let dir = temp_dir("mmproj-ambiguous");
+    fs::write(dir.join("qwen.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj-f16.gguf"), build_minimal_gguf("llama")).unwrap();
+
+    let found = find_mmproj(&dir.join("qwen.gguf"));
+    assert!(
+      found.is_none(),
+      "should ignore all anonymous projectors when multiple exist to avoid ambiguity"
+    );
+
+    // If a base name match is added, it should still be found
+    fs::write(dir.join("qwen-mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
+    let found = find_mmproj(&dir.join("qwen.gguf"));
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("qwen-mmproj.gguf"),
+      "base name match should still win even with ambiguous anonymous ones"
+    );
+
     fs::remove_dir_all(&dir).ok();
   }
 

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -129,6 +129,36 @@ fn is_projector_companion(path: &Path) -> bool {
     .unwrap_or(false)
 }
 
+/// Find the multimodal projector (mmproj) companion file for a given
+/// model path. The projector file is expected to be in the same
+/// directory with a `mmproj-<stem>.gguf` or `mmproj_<stem>.gguf`
+/// naming pattern, where `<stem>` is the model's file name without the
+/// `.gguf` extension. Returns `None` if no companion is found.
+pub fn find_mmproj(model_path: &Path) -> Option<PathBuf> {
+  let parent = model_path.parent()?;
+  let stem = model_path.file_stem()?.to_str()?;
+  for entry in std::fs::read_dir(parent).ok()? {
+    let entry = entry.ok()?;
+    let name = entry.file_name();
+    let name_str = name.to_str()?;
+    let is_mmproj = name_str.starts_with("mmproj-") || name_str.starts_with("mmproj_");
+    if !is_mmproj {
+      continue;
+    }
+    if let Some(rest) = name_str.strip_prefix("mmproj-") {
+      if rest == format!("{stem}.gguf") || rest == stem {
+        return Some(entry.path());
+      }
+    }
+    if let Some(rest) = name_str.strip_prefix("mmproj_") {
+      if rest == format!("{stem}.gguf") || rest == stem {
+        return Some(entry.path());
+      }
+    }
+  }
+  None
+}
+
 /// Concurrency cap for [`walk_root`]'s per-file parse. Default to
 /// `num_cpus()`-flavoured but capped — too many parallel
 /// `spawn_blocking` calls land everything on the blocking pool
@@ -689,5 +719,57 @@ mod tests {
       second_arch, "phi3",
       "size change must invalidate cache and re-parse"
     );
+  }
+
+  #[test]
+  fn find_mmproj_detects_mmproj_dash_prefix() {
+    let dir = temp_dir("mmproj-find");
+    fs::write(dir.join("model.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj-model.gguf"), build_minimal_gguf("llama")).unwrap();
+    let found = find_mmproj(&dir.join("model.gguf"));
+    assert!(found.is_some(), "find_mmproj must find mmproj-model.gguf");
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("mmproj-model.gguf")
+    );
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_detects_mmproj_underscore_prefix() {
+    let dir = temp_dir("mmproj-find-underscore");
+    fs::write(
+      dir.join("Qwen2.5-7B.Q4_K_M.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join("mmproj_Qwen2.5-7B.Q4_K_M.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    let found = find_mmproj(&dir.join("Qwen2.5-7B.Q4_K_M.gguf"));
+    assert!(
+      found.is_some(),
+      "find_mmproj must find mmproj_Qwen2.5-7B.Q4_K_M.gguf"
+    );
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("mmproj_Qwen2.5-7B.Q4_K_M.gguf")
+    );
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_returns_none_when_no_companion() {
+    let dir = temp_dir("mmproj-none");
+    fs::write(dir.join("model.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("unrelated.gguf"), build_minimal_gguf("llama")).unwrap();
+    let found = find_mmproj(&dir.join("model.gguf"));
+    assert!(
+      found.is_none(),
+      "find_mmproj must return None when no companion exists"
+    );
+    fs::remove_dir_all(&dir).ok();
   }
 }

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -176,7 +176,10 @@ fn strip_mmproj_markers(name: &str) -> String {
   };
   let mut s = s.to_lowercase();
 
-  if let Some(rest) = s.strip_prefix("mmproj-").or_else(|| s.strip_prefix("mmproj_")) {
+  if let Some(rest) = s
+    .strip_prefix("mmproj-")
+    .or_else(|| s.strip_prefix("mmproj_"))
+  {
     s = rest.to_string();
   }
 
@@ -197,82 +200,117 @@ fn strip_mmproj_markers(name: &str) -> String {
   s
 }
 
+/// Collect projector filenames for a diagnostic log line.
+fn projector_names(paths: &[PathBuf]) -> Vec<String> {
+  paths
+    .iter()
+    .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+    .collect()
+}
+
 /// Find the multimodal projector (mmproj) companion file for a given
 /// model path. The projector file is expected to be in the same
 /// directory.
 ///
-/// Matching ignores quantization labels in both filenames. A projector
-/// is matched if:
-/// 1. Its base name matches the model's base name.
-/// 2. It is an "anonymous" projector (e.g., `mmproj-f16.gguf` or
-///    `mmproj.gguf`), which serves as a fallback for any model in the
-///    same directory.
+/// Matching ignores quantization labels in both filenames. The rules,
+/// in order:
+///
+/// 1. A projector whose quant-stripped base name equals the model's
+///    wins. If several match (multiple models share the directory and
+///    their bases collide after quant-stripping), one is picked
+///    deterministically with a warning.
+/// 2. No name match, but the directory holds exactly one model and one
+///    projector → pair them. One model + one projector per folder is
+///    the dominant layout (HuggingFace snapshots, LM Studio), and
+///    upstream repos routinely name the projector generically
+///    (`mmproj-model-f16.gguf`) or after a different quant than the
+///    model, so a strict name match would miss the common case. Gating
+///    on a single model in the directory keeps a flat multi-model
+///    folder from cross-assigning one model's projector to another.
+/// 3. Otherwise, a lone "anonymous" projector (`mmproj.gguf`,
+///    `mmproj-f16.gguf`) is the directory's catch-all and is used.
+///    Anything else is genuinely ambiguous: emit nothing and let the
+///    user pass `--mmproj` rather than load a mismatched projector.
 pub fn find_mmproj(model_path: &Path) -> Option<PathBuf> {
   let parent = model_path.parent()?;
   let model_filename = model_path.file_name()?.to_str()?;
   let model_stem = model_path.file_stem()?.to_str()?;
+  // Launching a projector directly has no projector of its own.
+  if is_projector_companion(model_path) {
+    return None;
+  }
 
   let model_base = canonical_base(model_stem);
 
-  let mut candidates = Vec::new();
-  let mut anonymous_found = Vec::new();
+  let mut all_projectors: Vec<PathBuf> = Vec::new();
+  let mut base_matches: Vec<PathBuf> = Vec::new();
+  let mut anonymous: Vec<PathBuf> = Vec::new();
+  // Count sibling model files (non-projector `.gguf`s, including the
+  // model itself) so the single-projector fallback only fires when this
+  // is the only model in the directory.
+  let mut model_file_count = 0usize;
 
-  for entry in std::fs::read_dir(parent).ok()? {
-    let Ok(entry) = entry else {
-      continue;
-    };
+  for entry in std::fs::read_dir(parent).ok()?.flatten() {
     let path = entry.path();
     if !path.is_file() {
       continue;
     }
-
     let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
       continue;
     };
-    if name == model_filename || !is_projector_companion(&path) {
+    if !name.to_lowercase().ends_with(".gguf") {
       continue;
     }
-
-    let stripped_name = strip_mmproj_markers(name);
-    let proj_base = canonical_base(&stripped_name);
-
-    if !proj_base.is_empty() && proj_base == model_base {
-      // 1. Direct base-name match
-      candidates.push((100, path));
-    } else if proj_base.is_empty() {
-      // 2. Anonymous/Generic fallback
-      anonymous_found.push(path.clone());
-      candidates.push((10, path));
+    if !is_projector_companion(&path) {
+      model_file_count += 1;
+      continue;
     }
+    if name == model_filename {
+      continue;
+    }
+    let proj_base = canonical_base(&strip_mmproj_markers(name));
+    if proj_base.is_empty() {
+      anonymous.push(path.clone());
+    } else if proj_base == model_base {
+      base_matches.push(path.clone());
+    }
+    all_projectors.push(path);
   }
 
-  if anonymous_found.len() > 1 {
+  // 1. Name match wins.
+  if !base_matches.is_empty() {
+    base_matches.sort();
+    if base_matches.len() > 1 {
+      log::warn!(
+        "multiple mmproj candidates match model {model_filename}; using {}: {:?}",
+        base_matches[0]
+          .file_name()
+          .unwrap_or_default()
+          .to_string_lossy(),
+        projector_names(&base_matches),
+      );
+    }
+    return base_matches.into_iter().next();
+  }
+
+  // 2. Single model + single projector → pair them regardless of name.
+  if model_file_count == 1 && all_projectors.len() == 1 {
+    return all_projectors.into_iter().next();
+  }
+
+  // 3. Lone anonymous catch-all, else ambiguous → give up.
+  if anonymous.len() == 1 {
+    return anonymous.into_iter().next();
+  }
+  if !all_projectors.is_empty() {
     log::warn!(
-      "multiple anonymous mmproj files found in {}; ignoring fallbacks for {} to avoid ambiguity: {:?}",
+      "multiple mmproj files in {} but none match model {model_filename}; \
+       skipping auto-detection (pass --mmproj to choose): {:?}",
       parent.display(),
-      model_filename,
-      anonymous_found
-        .iter()
-        .map(|p| p.file_name().unwrap().to_string_lossy())
-        .collect::<Vec<_>>()
-    );
-    candidates.retain(|(score, _)| *score >= 100);
-  }
-
-  let named_candidates: Vec<_> = candidates.iter().filter(|(s, _)| *s >= 100).collect();
-  if named_candidates.len() > 1 {
-    log::warn!(
-      "multiple matching mmproj candidates for model {}; picking the first one: {:?}",
-      model_filename,
-      named_candidates
-        .iter()
-        .map(|(_, p)| p.file_name().unwrap().to_string_lossy())
-        .collect::<Vec<_>>()
+      projector_names(&all_projectors),
     );
   }
-
-  candidates.sort_by(|a, b| b.0.cmp(&a.0));
-  candidates.into_iter().next().map(|(_, p)| p)
+  None
 }
 
 /// Concurrency cap for [`walk_root`]'s per-file parse. Default to
@@ -536,16 +574,8 @@ mod tests {
       build_minimal_gguf("llama"),
     )
     .unwrap();
-    fs::write(
-      dir.join("model.mmproj.gguf"),
-      build_minimal_gguf("llama"),
-    )
-    .unwrap();
-    fs::write(
-      dir.join("mmproj-BF16.gguf"),
-      build_minimal_gguf("llama"),
-    )
-    .unwrap();
+    fs::write(dir.join("model.mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("mmproj-BF16.gguf"), build_minimal_gguf("llama")).unwrap();
     let paths = collect_gguf_paths(&dir, &[]);
     let names: Vec<String> = paths
       .iter()
@@ -865,7 +895,11 @@ mod tests {
   fn find_mmproj_detects_various_patterns() {
     let dir = temp_dir("mmproj-patterns");
     let model = "my-model";
-    fs::write(dir.join(format!("{model}.gguf")), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join(format!("{model}.gguf")),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
 
     let patterns = [
       format!("mmproj_{model}.gguf"),
@@ -917,9 +951,9 @@ mod tests {
       build_minimal_gguf("llama"),
     )
     .unwrap();
-    let found = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
+    let found_infix = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
     assert_eq!(
-      found.unwrap().file_name().and_then(|s| s.to_str()),
+      found_infix.unwrap().file_name().and_then(|s| s.to_str()),
       Some("Qwen2-7B.mmproj.gguf")
     );
 
@@ -930,9 +964,12 @@ mod tests {
       build_minimal_gguf("llama"),
     )
     .unwrap();
-    let found = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
+    let found_underscore = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
     assert_eq!(
-      found.unwrap().file_name().and_then(|s| s.to_str()),
+      found_underscore
+        .unwrap()
+        .file_name()
+        .and_then(|s| s.to_str()),
       Some("Qwen2_7B_mmproj.gguf")
     );
 
@@ -943,7 +980,11 @@ mod tests {
   fn find_mmproj_warns_on_multiple_named_candidates() {
     let dir = temp_dir("mmproj-multiple-named");
     let model = "my-model";
-    fs::write(dir.join(format!("{model}.gguf")), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join(format!("{model}.gguf")),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
     fs::write(
       dir.join(format!("mmproj-{model}-f16.gguf")),
       build_minimal_gguf("llama"),
@@ -976,9 +1017,9 @@ mod tests {
 
     fs::remove_file(dir.join("mmproj-BF16.gguf")).unwrap();
     fs::write(dir.join("mmproj-Q4_K_M.gguf"), build_minimal_gguf("llama")).unwrap();
-    let found = find_mmproj(&dir.join("model-Q4_K_M.gguf"));
+    let found_quant = find_mmproj(&dir.join("model-Q4_K_M.gguf"));
     assert_eq!(
-      found.unwrap().file_name().and_then(|s| s.to_str()),
+      found_quant.unwrap().file_name().and_then(|s| s.to_str()),
       Some("mmproj-Q4_K_M.gguf"),
       "anonymous match should work when only one exists"
     );
@@ -989,7 +1030,11 @@ mod tests {
   #[test]
   fn find_mmproj_handles_unsloth_mismatched_quants_when_single() {
     let dir = temp_dir("mmproj-unsloth-mismatch");
-    fs::write(dir.join("mimi-0.1.Q4_K_M.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join("mimi-0.1.Q4_K_M.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
     fs::write(dir.join("mmproj-f16.gguf"), build_minimal_gguf("llama")).unwrap();
 
     let found = find_mmproj(&dir.join("mimi-0.1.Q4_K_M.gguf"));
@@ -1020,9 +1065,9 @@ mod tests {
 
     // If a base name match is added, it should still be found
     fs::write(dir.join("qwen-mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
-    let found = find_mmproj(&dir.join("qwen.gguf"));
+    let found_named = find_mmproj(&dir.join("qwen.gguf"));
     assert_eq!(
-      found.unwrap().file_name().and_then(|s| s.to_str()),
+      found_named.unwrap().file_name().and_then(|s| s.to_str()),
       Some("qwen-mmproj.gguf"),
       "base name match should still win even with ambiguous anonymous ones"
     );
@@ -1041,14 +1086,80 @@ mod tests {
   #[test]
   fn find_mmproj_handles_separator_mismatch() {
     let dir = temp_dir("mmproj-sep-mismatch");
-    fs::write(dir.join("qwen2_7b_q4_k_m.gguf"), build_minimal_gguf("llama")).unwrap();
-    fs::write(dir.join("qwen2-7b-mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join("qwen2_7b_q4_k_m.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join("qwen2-7b-mmproj.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
 
     let found = find_mmproj(&dir.join("qwen2_7b_q4_k_m.gguf"));
     assert!(found.is_some());
     assert_eq!(
       found.unwrap().file_name().and_then(|s| s.to_str()),
       Some("qwen2-7b-mmproj.gguf")
+    );
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_uses_single_projector_with_generic_name() {
+    // ggml-org's official multimodal GGUF repos ship the projector as a
+    // generically-named `mmproj-model-f16.gguf` next to a descriptively
+    // named model. Its stripped base (`model`) matches neither the
+    // model name nor "empty", so name-matching alone misses it — the
+    // single-model + single-projector fallback must still pair them.
+    let dir = temp_dir("mmproj-generic-single");
+    fs::write(
+      dir.join("gemma-3-4b-it-Q4_K_M.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join("mmproj-model-f16.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+
+    let found = find_mmproj(&dir.join("gemma-3-4b-it-Q4_K_M.gguf"));
+    assert_eq!(
+      found.and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned())),
+      Some("mmproj-model-f16.gguf".to_string()),
+      "single projector in a single-model folder must pair regardless of name"
+    );
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_does_not_cross_assign_in_multi_model_dir() {
+    // Flat folder with two models but only one projector, named for the
+    // *other* model. Launching the projector-less model must not borrow
+    // the neighbour's projector — the single-projector fallback is gated
+    // on there being exactly one model in the directory.
+    let dir = temp_dir("mmproj-multi-model");
+    fs::write(dir.join("zephyr-7b.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("gemma-3-4b.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join("mmproj-gemma-3-4b-f16.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+
+    // gemma gets its named projector...
+    assert_eq!(
+      find_mmproj(&dir.join("gemma-3-4b.gguf"))
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned())),
+      Some("mmproj-gemma-3-4b-f16.gguf".to_string())
+    );
+    // ...but zephyr must not.
+    assert_eq!(
+      find_mmproj(&dir.join("zephyr-7b.gguf")),
+      None,
+      "must not cross-assign another model's projector"
     );
     fs::remove_dir_all(&dir).ok();
   }

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -128,18 +128,19 @@ fn is_projector_companion(path: &Path) -> bool {
     .and_then(|n| n.to_str())
     .map(|n| {
       let n = n.to_lowercase();
-      n.starts_with("mmproj-")
-        || n.starts_with("mmproj_")
-        || n.contains(".mmproj.")
-        || n.ends_with(".mmproj.gguf")
-        || n.ends_with("-mmproj.gguf")
-        || n.ends_with("_mmproj.gguf")
-        || n == "mmproj.gguf"
+      n.ends_with(".gguf")
+        && (n.starts_with("mmproj-")
+          || n.starts_with("mmproj_")
+          || n.contains(".mmproj.")
+          || n.ends_with(".mmproj.gguf")
+          || n.ends_with("-mmproj.gguf")
+          || n.ends_with("_mmproj.gguf")
+          || n == "mmproj.gguf")
     })
     .unwrap_or(false)
 }
 
-const QUANT_PATTERN: &str = r"\b(bf16|f16|f32|mxfp4_moe|iq[1-4](_?s|_?xs|_?xxs|_?m|_?nl|_?nl_xl)?|q[2-8](_?[01])?(_?k)?(_?[sml]|_?xl)?)\b";
+const QUANT_PATTERN: &str = r"(?:^|[-._])(bf16|f16|f32|mxfp4_moe|iq[1-8](_?s|_?xs|_?xxs|_?m|_?nl|_?nl_xl)?|q[1-8](_?[01])?(_?k)?(_?[sml]|_?xl)?)\b";
 
 /// Strip all quantization tokens and separators from a name to derive
 /// a canonical base name for matching.
@@ -157,36 +158,37 @@ fn canonical_base(s: &str) -> String {
     s.replace_range(start..end, "");
   }
 
-  // Clean up separators and common "UD" (Up/Down) markers
-  s.trim_matches(|c| c == '.' || c == '-' || c == '_')
-    .replace("-ud", "")
-    .replace(".ud", "")
-    .replace("_ud", "")
-    .trim_matches(|c| c == '.' || c == '-' || c == '_')
-    .to_string()
+  // Normalize all separators to dashes and collapse multiple dashes
+  // so that "model_name" matches "model-name".
+  s = s.replace(['.', '_'], "-");
+  while s.contains("--") {
+    s = s.replace("--", "-");
+  }
+
+  s.trim_matches('-').to_string()
 }
 
 /// Strip mmproj-related prefixes and suffixes to find the base model
 /// name part.
 fn strip_mmproj_markers(name: &str) -> String {
-  let name = name.strip_suffix(".gguf").unwrap_or(name);
-  let mut s = name.to_lowercase();
+  let Some(s) = name.strip_suffix(".gguf") else {
+    return name.to_lowercase();
+  };
+  let mut s = s.to_lowercase();
 
-  if s.starts_with("mmproj-") {
-    s = s["mmproj-".len()..].to_string();
-  } else if s.starts_with("mmproj_") {
-    s = s["mmproj_".len()..].to_string();
+  if let Some(rest) = s.strip_prefix("mmproj-").or_else(|| s.strip_prefix("mmproj_")) {
+    s = rest.to_string();
   }
 
-  if s.ends_with("-mmproj") {
-    s = s[..s.len() - "-mmproj".len()].to_string();
-  } else if s.ends_with("_mmproj") {
-    s = s[..s.len() - "_mmproj".len()].to_string();
-  } else if s.contains(".mmproj.") {
-    s = s.replace(".mmproj.", ".");
-  } else if s.ends_with(".mmproj") {
-    s = s[..s.len() - ".mmproj".len()].to_string();
+  if let Some(rest) = s
+    .strip_suffix("-mmproj")
+    .or_else(|| s.strip_suffix("_mmproj"))
+    .or_else(|| s.strip_suffix(".mmproj"))
+  {
+    s = rest.to_string();
   }
+
+  s = s.replace(".mmproj.", ".");
 
   if s == "mmproj" {
     return "".to_string();
@@ -255,6 +257,18 @@ pub fn find_mmproj(model_path: &Path) -> Option<PathBuf> {
         .collect::<Vec<_>>()
     );
     candidates.retain(|(score, _)| *score >= 100);
+  }
+
+  let named_candidates: Vec<_> = candidates.iter().filter(|(s, _)| *s >= 100).collect();
+  if named_candidates.len() > 1 {
+    log::warn!(
+      "multiple matching mmproj candidates for model {}; picking the first one: {:?}",
+      model_filename,
+      named_candidates
+        .iter()
+        .map(|(_, p)| p.file_name().unwrap().to_string_lossy())
+        .collect::<Vec<_>>()
+    );
   }
 
   candidates.sort_by(|a, b| b.0.cmp(&a.0));
@@ -909,6 +923,42 @@ mod tests {
       Some("Qwen2-7B.mmproj.gguf")
     );
 
+    // Test underscore separator for quant (regression test for Regex boundary)
+    fs::remove_file(dir.join("Qwen2-7B.mmproj.gguf")).unwrap();
+    fs::write(
+      dir.join("Qwen2_7B_mmproj.gguf"),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    let found = find_mmproj(&dir.join("Qwen2-7B-Q4_K_M.gguf"));
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("Qwen2_7B_mmproj.gguf")
+    );
+
+    fs::remove_dir_all(&dir).ok();
+  }
+
+  #[test]
+  fn find_mmproj_warns_on_multiple_named_candidates() {
+    let dir = temp_dir("mmproj-multiple-named");
+    let model = "my-model";
+    fs::write(dir.join(format!("{model}.gguf")), build_minimal_gguf("llama")).unwrap();
+    fs::write(
+      dir.join(format!("mmproj-{model}-f16.gguf")),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+    fs::write(
+      dir.join(format!("mmproj-{model}-bf16.gguf")),
+      build_minimal_gguf("llama"),
+    )
+    .unwrap();
+
+    let found = find_mmproj(&dir.join(format!("{model}.gguf")));
+    assert!(found.is_some());
+    // Both are equally valid named candidates, pick the first one (arbitrary).
+    // The log warning should have triggered.
     fs::remove_dir_all(&dir).ok();
   }
 
@@ -981,14 +1031,24 @@ mod tests {
   }
 
   #[test]
-  fn find_mmproj_returns_none_when_no_companion() {
-    let dir = temp_dir("mmproj-none");
-    fs::write(dir.join("model.gguf"), build_minimal_gguf("llama")).unwrap();
-    fs::write(dir.join("unrelated.gguf"), build_minimal_gguf("llama")).unwrap();
-    let found = find_mmproj(&dir.join("model.gguf"));
-    assert!(
-      found.is_none(),
-      "find_mmproj must return None when no companion exists"
+  fn test_canonical_base_normalization() {
+    assert_eq!(canonical_base("Qwen2-7B-Q4_K_M"), "qwen2-7b");
+    assert_eq!(canonical_base("Qwen2_7B_Q4_K_M"), "qwen2-7b");
+    assert_eq!(canonical_base("model...name---_"), "model-name");
+    assert_eq!(canonical_base("model-f16"), "model");
+  }
+
+  #[test]
+  fn find_mmproj_handles_separator_mismatch() {
+    let dir = temp_dir("mmproj-sep-mismatch");
+    fs::write(dir.join("qwen2_7b_q4_k_m.gguf"), build_minimal_gguf("llama")).unwrap();
+    fs::write(dir.join("qwen2-7b-mmproj.gguf"), build_minimal_gguf("llama")).unwrap();
+
+    let found = find_mmproj(&dir.join("qwen2_7b_q4_k_m.gguf"));
+    assert!(found.is_some());
+    assert_eq!(
+      found.unwrap().file_name().and_then(|s| s.to_str()),
+      Some("qwen2-7b-mmproj.gguf")
     );
     fs::remove_dir_all(&dir).ok();
   }

--- a/src/ipc/methods.rs
+++ b/src/ipc/methods.rs
@@ -958,6 +958,13 @@ pub(crate) struct StartParams {
   /// doesn't model. Appended after the resolved knobs.
   #[serde(default)]
   pub(crate) extras: Vec<String>,
+  /// Optional path to a multimodal projector (mmproj) file. When
+  /// `None`, the daemon auto-detects by scanning the parent
+  /// directory of the model for a `mmproj-<stem>.gguf` companion.
+  /// Set to `Some(path)` to override the auto-detection, or leave
+  /// as `None` to let the daemon find it automatically.
+  #[serde(default)]
+  pub(crate) mmproj_path: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Clone, Copy)]
@@ -1170,6 +1177,10 @@ pub(crate) async fn start_model_inner(
   let mut launch_params = LaunchParams::new(parsed.model_path.clone(), mode);
   launch_params.port = Some(port);
   launch_params.extras = parsed.extras.into_iter().map(OsString::from).collect();
+  launch_params.mmproj_path = parsed
+    .mmproj_path
+    .clone()
+    .or_else(|| crate::discovery::scanner::find_mmproj(&parsed.model_path));
 
   // Merge the caller's top-level `ctx` and `reasoning` into the
   // User-layer typed knobs so they participate in the resolver chain

--- a/src/ipc/methods.rs
+++ b/src/ipc/methods.rs
@@ -1177,10 +1177,18 @@ pub(crate) async fn start_model_inner(
   let mut launch_params = LaunchParams::new(parsed.model_path.clone(), mode);
   launch_params.port = Some(port);
   launch_params.extras = parsed.extras.into_iter().map(OsString::from).collect();
-  launch_params.mmproj_path = parsed
-    .mmproj_path
-    .clone()
-    .or_else(|| crate::discovery::scanner::find_mmproj(&parsed.model_path));
+  // Resolve the multimodal projector: an explicit `mmproj_path` wins;
+  // otherwise auto-detect a companion next to the model — unless the
+  // caller is already managing the projector through `extras`
+  // (`--mmproj` to pin a path, `--no-mmproj` to force text-only), in
+  // which case auto-detection would only emit a redundant second flag.
+  launch_params.mmproj_path = parsed.mmproj_path.clone().or_else(|| {
+    if extras_manage_mmproj(&launch_params.extras) {
+      None
+    } else {
+      crate::discovery::scanner::find_mmproj(&parsed.model_path)
+    }
+  });
 
   // Merge the caller's top-level `ctx` and `reasoning` into the
   // User-layer typed knobs so they participate in the resolver chain
@@ -1520,6 +1528,21 @@ fn resolve_model_id_and_arch(
   Ok((id, arch))
 }
 
+/// Does the caller's `extras` tail already manage the multimodal
+/// projector? `--mmproj <path>` pins a projector and `--no-mmproj`
+/// force-disables it; in either case the daemon must not auto-detect
+/// one too. Matches the flag head in both space form (`--mmproj`) and
+/// equals form (`--mmproj=/path`), case-insensitively. `--no-mmproj-offload`
+/// (offload tuning, projector still on) is left to auto-detect, so the
+/// match is exact rather than a prefix test.
+fn extras_manage_mmproj(extras: &[OsString]) -> bool {
+  extras.iter().any(|e| {
+    let lossy = e.to_string_lossy();
+    let head = lossy.split('=').next().unwrap_or(&lossy);
+    head.eq_ignore_ascii_case("--mmproj") || head.eq_ignore_ascii_case("--no-mmproj")
+  })
+}
+
 /// Total on-disk weight bytes for the model the launch handler is
 /// about to spawn. Prefers the catalog row (which already includes
 /// split-shard aggregation via `discovery::shard_sizes`); falls back
@@ -1789,6 +1812,27 @@ mod tests {
 
   fn ctx() -> MethodContext {
     MethodContext::new(ShutdownToken::new())
+  }
+
+  #[test]
+  fn extras_manage_mmproj_detects_explicit_projector_flags() {
+    let pin = vec![OsString::from("--mmproj"), OsString::from("/m/p.gguf")];
+    assert!(extras_manage_mmproj(&pin), "space-form --mmproj");
+    let pin_eq = vec![OsString::from("--MMPROJ=/m/p.gguf")];
+    assert!(
+      extras_manage_mmproj(&pin_eq),
+      "equals-form, case-insensitive"
+    );
+    let disable = vec![OsString::from("--no-mmproj")];
+    assert!(extras_manage_mmproj(&disable), "--no-mmproj force-disable");
+    // Offload tuning leaves the projector on → auto-detect still runs.
+    let offload = vec![OsString::from("--no-mmproj-offload")];
+    assert!(
+      !extras_manage_mmproj(&offload),
+      "--no-mmproj-offload is not projector management"
+    );
+    let unrelated = vec![OsString::from("--threads"), OsString::from("8")];
+    assert!(!extras_manage_mmproj(&unrelated));
   }
 
   #[tokio::test]

--- a/src/launch/params.rs
+++ b/src/launch/params.rs
@@ -166,6 +166,13 @@ pub struct LaunchParams {
   /// documented on the Settings tab.
   #[serde(default)]
   pub extras: Vec<OsString>,
+  /// Optional path to a multimodal projector (mmproj) file. When set,
+  /// the supervisor appends `--mmproj <path>` to the llama-server
+  /// argv. The file is auto-detected by scanning the parent directory
+  /// of the model for a `mmproj-<stem>.gguf` or `mmproj_<stem>.gguf`
+  /// companion.
+  #[serde(default)]
+  pub mmproj_path: Option<PathBuf>,
 }
 
 impl LaunchParams {
@@ -178,6 +185,7 @@ impl LaunchParams {
       reasoning: false,
       knobs: TypedKnobs::default(),
       extras: Vec::new(),
+      mmproj_path: None,
     }
   }
 }
@@ -465,6 +473,10 @@ pub fn compose(params: &LaunchParams, allocated_port: u16) -> Vec<OsString> {
   argv.push(allocated_port.to_string().into());
   argv.push("-m".into());
   argv.push(params.model_path.clone().into());
+  if let Some(ref mmproj) = params.mmproj_path {
+    argv.push("--mmproj".into());
+    argv.push(mmproj.clone().into());
+  }
   match params.mode {
     LaunchMode::Chat => {}
     LaunchMode::Embedding => argv.push("--embeddings".into()),
@@ -1086,6 +1098,22 @@ mod tests {
     }
 
     restore();
+  }
+
+  #[test]
+  fn compose_emits_mmproj_flag_when_path_set() {
+    let mut p = base_params();
+    p.mmproj_path = Some(PathBuf::from("/m/mmproj-model.gguf"));
+    let argv = strs(&compose(&p, 41100));
+    let i = argv.iter().position(|a| a == "--mmproj").unwrap();
+    assert_eq!(argv[i + 1], "/m/mmproj-model.gguf");
+  }
+
+  #[test]
+  fn compose_omits_mmproj_flag_when_path_not_set() {
+    let p = base_params();
+    let argv = strs(&compose(&p, 41100));
+    assert!(!argv.iter().any(|a| a == "--mmproj"));
   }
 
   #[test]

--- a/tests/start_model_ipc_test.rs
+++ b/tests/start_model_ipc_test.rs
@@ -62,6 +62,12 @@ async fn start_model_drives_supervisor_status_logs_stop_and_last_params() {
   let model_dir = unique_temp("happy-models");
   let model_path = model_dir.join("m.gguf");
   std::fs::write(&model_path, build_minimal_gguf("llama")).unwrap();
+  // A multimodal projector companion next to the model (issue #13).
+  // The daemon must auto-detect it and thread `--mmproj` into the spawn
+  // params — asserted on the running snapshot below. Folded into this
+  // happy-path test rather than a separate daemon-spawning test to
+  // avoid adding parallel load to this contended integration binary.
+  std::fs::write(model_dir.join("mmproj-m.gguf"), build_minimal_gguf("llama")).unwrap();
   let model_path_canon = llamastash::util::paths::canonicalize(&model_path).unwrap();
 
   let opts = DaemonOptions {
@@ -170,6 +176,15 @@ async fn start_model_drives_supervisor_status_logs_stop_and_last_params() {
     s.running.len(),
     1,
     "running snapshot must contain the active launch"
+  );
+  // The auto-detected projector rode through into the spawn params.
+  // Compare against the canonical parent: the daemon resolves the
+  // projector relative to the canonical model path, which differs from
+  // `model_dir` on macOS (/tmp → /private/tmp).
+  assert_eq!(
+    s.running[0].params.mmproj_path,
+    Some(model_path_canon.parent().unwrap().join("mmproj-m.gguf")),
+    "daemon must auto-detect the mmproj companion and thread it into spawn params"
   );
 
   // 5) stop_model brings it down + drops the running snapshot.


### PR DESCRIPTION
Resolves issue #13

## What
Auto-detects multimodal projector (mmproj) companion files when launching a model.

## Why
Multimodal models (Gemma 4, Qwen 3.6, etc.) ship the projector 
as a separate `.gguf` file alongside the main model. In llama.cpp, users 
pass `--mmproj` manually, but now llamastash will do it for them.

## How
- `scanner::find_mmproj()` scans the model's parent directory for `mmproj-*` 
  or `mmproj_*` companions
- `start_model` IPC handler uses this as a fallback when `mmproj_path` is 
  not explicitly provided
- `--mmproj <path>` is appended to the llama-server argv

## Testing
- `cargo test --features test-fixtures` — all pass
- Manual: launched a Qwen2.5-VL model with its `mmproj-Qwen2.5-7B.Q4_K_M.gguf` 
  companion in the same directory
- Built release and tested on Arch Linux, multimodal input works great

Forgive any mistakes I might've made, still new to git & github lol