### PR TITLE
test: de-flake CI (port TOCTOU fix + migrate test legs to cargo-nextest)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,34 @@
+# nextest config. `.github/workflows/ci.yml` runs the `ci` profile; the
+# default profile keeps local `cargo nextest run` fast.
+#
+# The daemon/proxy integration tests each boot a full daemon (control
+# plane + proxy listener + supervised tasks). Several booting at once
+# oversubscribe a 3-4 core CI runner and starve a listener past its
+# readiness deadline -- the off-Linux flake. libtest's per-binary
+# `--test-threads` can't bound concurrency across binaries; nextest's
+# global scheduler + a test-group can.
+
+# Bound how many daemon-spawning tests run at once across the WHOLE run
+# (not per-binary), so several daemons never boot together on a few-core
+# runner. Assigned to the matching binaries via the override below.
+[test-groups]
+daemon-bound = { max-threads = 4 }
+
+[[profile.default.overrides]]
+filter = 'binary(/^(proxy_|daemon_|control_plane|supervisor_|start_model|lemonade_|tui_|init_orchestration|list_models|cli_integration|uat_lifecycle)/)'
+test-group = 'daemon-bound'
+
+[profile.ci]
+# Retry environmental flake (a port-reuse race, a slow-runner deadline
+# miss) instead of failing the run; a real logic bug fails every attempt.
+retries = 2
+fail-fast = false
+# Flag slow tests and terminate a genuinely hung one rather than waiting
+# out the job timeout.
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+# Profile overrides don't inherit the default profile's, so repeat the
+# daemon-bound assignment here for the CI profile.
+[[profile.ci.overrides]]
+filter = 'binary(/^(proxy_|daemon_|control_plane|supervisor_|start_model|lemonade_|tui_|init_orchestration|list_models|cli_integration|uat_lifecycle)/)'
+test-group = 'daemon-bound'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,32 +83,39 @@ jobs:
         # constraint (Unit 4 of the Windows+HTTP-IPC plan) but pinning
         # /tmp is still cheap and avoids any other long-path surprise.
         # Windows uses the runner's default temp dir (no TMPDIR override).
-        # `test_args` caps libtest's per-binary parallelism on the
-        # slower / fewer-core macOS and Windows runners. Each daemon /
-        # proxy integration test boots a full daemon (control plane +
-        # proxy listener + supervised tasks); running several at once on
-        # a 3-4 core runner oversubscribes the box and starves a listener
-        # past its fixed readiness deadline — the flaky timeouts that
-        # only surface off-Linux. ubuntu has the cores + fast threads to
-        # run unconstrained.
+        # Test concurrency is bounded by nextest's `daemon-bound`
+        # test-group (.config/nextest.toml): it caps how many
+        # daemon-spawning tests run at once across the whole run —
+        # globally, not per-binary like libtest's old `--test-threads`
+        # band-aid. Each such test boots a full daemon (control plane +
+        # proxy listener + supervised tasks); several at once
+        # oversubscribe a 3-4 core runner and starve a listener past its
+        # readiness deadline (the off-Linux flake). The `ci` profile also
+        # retries to absorb any residual environmental flake.
         include:
           - os: ubuntu-latest
             tmpdir_override: /tmp
-            test_args: ""
           - os: macos-latest
             tmpdir_override: /tmp
-            test_args: "-- --test-threads=2"
           - os: windows-latest
             tmpdir_override: ""
-            test_args: "-- --test-threads=2"
     runs-on: ${{ matrix.os }}
     needs: prepare
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test
-        run: cargo test --features ${{ matrix.features }} --workspace ${{ matrix.test_args }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: cargo nextest run
+        run: cargo nextest run --profile ci --features ${{ matrix.features }} --workspace
+        env:
+          RUST_BACKTRACE: 1
+          TMPDIR: ${{ matrix.tmpdir_override }}
+      # nextest doesn't run doctests — cover them separately.
+      - name: cargo test --doc
+        run: cargo test --doc --features ${{ matrix.features }} --workspace
         env:
           RUST_BACKTRACE: 1
           TMPDIR: ${{ matrix.tmpdir_override }}

--- a/src/daemon/orphans.rs
+++ b/src/daemon/orphans.rs
@@ -408,6 +408,11 @@ mod tests {
     }
   }
 
+  /// A loopback port that nothing is listening on: bind ephemeral, read
+  /// it, drop. Only for the "connection refused" probe case below — the
+  /// listening cases use `spawn_one_shot`, which keeps its port so there's
+  /// no reuse window. A rare post-drop reuse here is absorbed by nextest
+  /// `retries` on CI.
   fn allocate_port() -> u16 {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
     let p = l.local_addr().unwrap().port();
@@ -415,15 +420,21 @@ mod tests {
     p
   }
 
-  /// Spin up a tiny single-shot HTTP responder on `port` returning
-  /// the supplied (status, body) pair to one connection. Used by
-  /// the orphan probe tests so we don't need the full
-  /// `fake_llama_server` binary just to validate the matcher.
-  async fn spawn_one_shot(port: u16, status: u16, body: String) -> tokio::task::JoinHandle<()> {
-    let listener = TcpListener::bind(("127.0.0.1", port))
+  /// Spin up a tiny single-shot HTTP responder on an OS-assigned loopback
+  /// port, returning `(task, port)`. Binding the port here and holding it —
+  /// rather than taking a pre-picked number — closes the bind-drop-rebind
+  /// race that panicked CI with `AddrInUse` (the port could be reused
+  /// between a separate allocate and this bind). Used by the orphan probe
+  /// tests so we don't need the full `fake_llama_server` binary.
+  async fn spawn_one_shot(status: u16, body: String) -> (tokio::task::JoinHandle<()>, u16) {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
       .await
       .expect("bind probe responder");
-    tokio::spawn(async move {
+    let port = listener
+      .local_addr()
+      .expect("probe responder local_addr")
+      .port();
+    let task = tokio::spawn(async move {
       if let Ok((mut sock, _)) = listener.accept().await {
         let mut buf = [0u8; 1024];
         let _ = sock.read(&mut buf).await;
@@ -440,7 +451,8 @@ mod tests {
         let _ = sock.write_all(body.as_bytes()).await;
         let _ = sock.shutdown().await;
       }
-    })
+    });
+    (task, port)
   }
 
   #[test]
@@ -574,13 +586,12 @@ mod tests {
   #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
   async fn live_pid_with_matching_port_and_model_path_adopts() {
     let live = std::process::id() as i32;
-    let port = allocate_port();
     let body = serde_json::json!({
       "object": "list",
       "data": [{"id": "/m/match.gguf", "object": "model"}],
     })
     .to_string();
-    let _resp = spawn_one_shot(port, 200, body).await;
+    let (_resp, port) = spawn_one_shot(200, body).await;
 
     let recorded = vec![fake_snapshot(live, port, "/m/match.gguf", 1)];
     let report = sweep(SweepInputs {
@@ -600,13 +611,12 @@ mod tests {
     // builds echoed). The recorded path is absolute; the sweep must
     // still adopt when the basenames line up.
     let live = std::process::id() as i32;
-    let port = allocate_port();
     let body = serde_json::json!({
       "object": "list",
       "data": [{"id": "match.gguf", "object": "model"}],
     })
     .to_string();
-    let _resp = spawn_one_shot(port, 200, body).await;
+    let (_resp, port) = spawn_one_shot(200, body).await;
 
     let recorded = vec![fake_snapshot(live, port, "/m/match.gguf", 1)];
     let report = sweep(SweepInputs {
@@ -630,13 +640,12 @@ mod tests {
     // bind a stale `state.json::running` entry to an unrelated
     // process. Three-factor confirmation rejects it.
     let live = std::process::id() as i32;
-    let port = allocate_port();
     let body = serde_json::json!({
       "object": "list",
       "data": [{"id": "/m/different.gguf", "object": "model"}],
     })
     .to_string();
-    let _resp = spawn_one_shot(port, 200, body).await;
+    let (_resp, port) = spawn_one_shot(200, body).await;
 
     let recorded = vec![fake_snapshot(live, port, "/m/expected.gguf", 1)];
     let report = sweep(SweepInputs {


### PR DESCRIPTION
PR #40's CI hit a hard failure on the ubuntu test leg: `daemon::orphans::tests::live_pid_with_basename_only_id_adopts` panicked with `AddrInUse`. It was a bind-drop-rebind port race, and it bit Linux too, not just the off-Linux flakes we'd been chasing.

So this does two things.

### Fix the port TOCTOU

`spawn_one_shot` in `src/daemon/orphans.rs` used to take a port that a separate `allocate_port` had bound and dropped, then rebind it. The kernel could hand that port to another parallel test in the gap. Now `spawn_one_shot` binds an ephemeral port itself and holds it, returning the actual port to the caller. No gap, no rebind.

`pick_free_port` in `tests/proxy_listener_test.rs` has the same shape but I left it as-is on purpose: the proxy already scans `port..=port+5` and the test reads the real bound port back from `status`, so it self-recovers. nextest retries cover the residual race. Adding a pre-bound-listener seam to the production proxy just for a test was not worth it.

### Migrate the CI test legs to cargo-nextest

This replaces the per-binary `--test-threads=2` band-aid on the macOS/Windows legs with something that actually bounds concurrency across the whole run.

- `.config/nextest.toml` defines a `daemon-bound` test-group (`max-threads = 4`) covering the daemon-spawning integration binaries (proxy, daemon, control_plane, supervisor, start_model, lemonade, tui, init_orchestration, list_models, cli_integration, uat_lifecycle). That stops several full daemons booting at once and starving a listener past its readiness deadline.
- The `ci` profile adds `retries = 2` (absorbs residual environmental flake instead of failing the run) and `slow-timeout` with `terminate-after` (kills a genuine hang).
- The `test` matrix job now runs `cargo nextest run --profile ci`, plus a separate `cargo test --doc` step since nextest does not run doctests. `test-no-features` and nightly coverage stay on `cargo test`.

### Validation

Local full run under the ci profile, both feature combos green:

- `cargo nextest run --profile ci --features test-fixtures --workspace` -> 1949 passed
- uat leg (`--features test-fixtures,uat`) green
- `cargo test --doc`, `cargo fmt --check`, `cargo clippy -D warnings` all clean

### Not included

TODO.md has unrelated in-flight edits right now (the R5/MLX roadmap reshuffle), so I kept the flake-section TODO updates out of this PR to avoid bundling that WIP. Happy to land those once the TODO WIP is sorted.
