### PR TITLE
fix(daemon): inherit extras from last_params on proxy auto-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to LlamaStash will be documented in this file. The format fo
 ### Fixed
 
 - TUI Settings knob rows no longer wrap when a `(model/server default)` source label doesn't fit the pane — they truncate on one line with `…`, so cycling presets or live updates don't make the form jump. The running view and the editable form now render through one shared path, so both show/hide/truncate these labels identically.
+- Free-form `llama-server` flags (e.g. `--chat-template-file`, `--mmproj`) now survive a proxy auto-start reload: an auto-started model inherits the extras from its last manual launch instead of dropping them. Manual launches still take their extras verbatim, so clearing them works. (#49)
 
 ## [0.0.5] — 2026-06-25
 

--- a/src/daemon/launch_service.rs
+++ b/src/daemon/launch_service.rs
@@ -26,7 +26,7 @@ use crate::daemon::registry::LaunchId;
 use crate::daemon::shutdown::ShutdownToken;
 use crate::daemon::state_store::RunningSnapshot;
 use crate::daemon::supervisor::{
-  spawn as supervisor_spawn, ManagedModel, ManagedSpawn, ManagedState,
+  spawn as supervisor_spawn, LaunchOrigin, ManagedModel, ManagedSpawn, ManagedState,
 };
 use crate::gguf::header::{read_path as read_gguf_header, HeaderReadOptions};
 use crate::gguf::identity::ModelId;
@@ -258,16 +258,22 @@ pub(crate) async fn compose_and_spawn(
   // (identity rule); an explicit choice from `start --backend` / the TUI
   // picker overrides it. Resolved into a backend at the selection seam below.
   launch_params.backend = parsed.backend.unwrap_or_default();
-  // Resolve extras from the caller's request. If the caller didn't provide
-  // extras (e.g. proxy auto-start), inherit from the model's last_params so
-  // free-form flags (`--chat-template-file`, `--mmproj`, etc.) survive reload
-  // cycles. When the caller *does* provide extras — including an empty vec —
-  // use them verbatim (the TUI always sends extras, even when cleared).
-  launch_params.extras = if parsed.extras.is_empty() {
+  // The model's last successful launch params. Taken once here and reused
+  // for the last-used knob layer below, so state is cloned a single time.
+  let last_params = {
     let snap = ctx.state.snapshot().await;
-    snap
-      .last_params_map()
-      .get(&identity)
+    snap.last_params_map().get(&identity).map(|p| (**p).clone())
+  };
+
+  // Free-form extras. A proxy auto-start arrives with an empty request, so
+  // it inherits the model's last_params extras to keep flags like
+  // `--chat-template-file` / `--mmproj` across reload cycles. Manual launches
+  // (TUI / `llamastash start` / IPC `start_model`) are taken verbatim, so a
+  // user who clears extras actually gets none. The empty-vs-set check can't
+  // tell a cleared manual launch from an auto-start, but the origin can.
+  launch_params.extras = if origin == LaunchOrigin::AutoStart {
+    last_params
+      .as_ref()
       .map(|p| p.extras.clone())
       .unwrap_or_default()
   } else {
@@ -300,16 +306,12 @@ pub(crate) async fn compose_and_spawn(
     user_knobs.reasoning = parsed.reasoning.map(KnobValue::Set);
   }
 
-  // Pull the model's last_params from persisted state so a returning
-  // user inherits the knobs they last shipped.
-  let last_params_knobs = {
-    let snap = ctx.state.snapshot().await;
-    snap
-      .last_params_map()
-      .get(&identity)
-      .map(|p| p.knobs.clone())
-      .unwrap_or_default()
-  };
+  // Last-used knobs from the snapshot taken above, so a returning user
+  // inherits the knobs they last shipped.
+  let last_params_knobs = last_params
+    .as_ref()
+    .map(|p| p.knobs.clone())
+    .unwrap_or_default();
   let empty_yaml = crate::config::TypedKnobs::default();
   let yaml_knobs = arch
     .as_deref()

--- a/src/daemon/launch_service.rs
+++ b/src/daemon/launch_service.rs
@@ -258,7 +258,21 @@ pub(crate) async fn compose_and_spawn(
   // (identity rule); an explicit choice from `start --backend` / the TUI
   // picker overrides it. Resolved into a backend at the selection seam below.
   launch_params.backend = parsed.backend.unwrap_or_default();
-  launch_params.extras = parsed.extras.into_iter().map(OsString::from).collect();
+  // Resolve extras from the caller's request. If the caller didn't provide
+  // extras (e.g. proxy auto-start), inherit from the model's last_params so
+  // free-form flags (`--chat-template-file`, `--mmproj`, etc.) survive reload
+  // cycles. When the caller *does* provide extras — including an empty vec —
+  // use them verbatim (the TUI always sends extras, even when cleared).
+  launch_params.extras = if parsed.extras.is_empty() {
+    let snap = ctx.state.snapshot().await;
+    snap
+      .last_params_map()
+      .get(&identity)
+      .map(|p| p.extras.clone())
+      .unwrap_or_default()
+  } else {
+    parsed.extras.into_iter().map(OsString::from).collect()
+  };
   // Resolve the multimodal projector: an explicit `mmproj_path` wins;
   // otherwise auto-detect a companion next to the model — unless the
   // caller is already managing the projector through `extras`

--- a/tests/start_model_ipc_test.rs
+++ b/tests/start_model_ipc_test.rs
@@ -639,6 +639,121 @@ async fn last_params_persists_only_user_supplied_knob_deltas() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn manual_start_with_no_extras_does_not_inherit_last_params_extras() {
+  // Proxy auto-start inherits last_params extras so free-form flags
+  // survive reload; a *manual* launch must NOT. Keying the inheritance
+  // off `parsed.extras.is_empty()` would conflate the two, so a user
+  // who clears their extras would silently get the old ones back and
+  // have no way to launch with zero extras. The gate is the launch
+  // origin, not the empty vec — this locks that in.
+  let state = unique_temp("manual-extras-no-inherit");
+  let model_dir = unique_temp("manual-extras-no-inherit-models");
+  let model_path = model_dir.join("m.gguf");
+  std::fs::write(&model_path, build_minimal_gguf("llama")).unwrap();
+  let model_path_canon = llamastash::util::paths::canonicalize(&model_path).unwrap();
+
+  // Two-port range so call 2 has somewhere to land after call 1 stops.
+  let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+  let p0 = probe.local_addr().unwrap().port();
+  drop(probe);
+  let probe2 = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+  let p1 = probe2.local_addr().unwrap().port();
+  drop(probe2);
+  let (lo, hi) = if p0 < p1 { (p0, p1) } else { (p1, p0) };
+
+  let opts = DaemonOptions {
+    binary: Some(fake_binary()),
+    port_range: PortRange { start: lo, end: hi },
+    ..DaemonOptions::rooted_at(state.clone())
+  };
+  let socket = opts.state_dir.clone();
+  let state_dir = opts.state_dir.clone();
+  let daemon = tokio::spawn(async move { run_foreground(opts).await });
+  wait_for_socket(&socket).await;
+  let mut client = Client::connect(&socket).await.expect("connect");
+
+  // Call 1 (manual): ship a free-form extra. After Ready it persists
+  // into last_params, where call 2's resolver could pick it up.
+  let first = client
+    .call(
+      "start_model",
+      Some(json!({
+        "model_path": &model_path_canon,
+        "extras": ["--chat-template-file", "/tmp/custom.jinja"],
+      })),
+    )
+    .await
+    .expect("start_model call 1");
+  let first_launch = first["launch_id"].as_str().unwrap().to_string();
+
+  // Wait for call 1's extras to land on disk (60 s for slow CI runners,
+  // matching the sibling last_params tests).
+  let deadline = std::time::Instant::now() + Duration::from_secs(60);
+  loop {
+    let s = state_store::load(&state_dir).expect("load state");
+    if s.last_params.first().is_some_and(|e| {
+      e.params
+        .extras
+        .iter()
+        .any(|x| x.to_str() == Some("--chat-template-file"))
+    }) {
+      break;
+    }
+    if std::time::Instant::now() > deadline {
+      panic!("call 1 last_params.extras never persisted");
+    }
+    tokio::time::sleep(Duration::from_millis(40)).await;
+  }
+
+  // Stop call 1 to free its port.
+  let _ = client
+    .call(
+      "stop_model",
+      Some(json!({"launch_id": &first_launch, "grace_secs": 5})),
+    )
+    .await
+    .expect("stop_model");
+
+  // Call 2 (manual): no extras, but a distinguishing knob (`mlock`) so
+  // we can tell call 2's persisted entry apart from call 1's.
+  let _ = client
+    .call(
+      "start_model",
+      Some(json!({
+        "model_path": &model_path_canon,
+        "knobs": {"mlock": true},
+      })),
+    )
+    .await
+    .expect("start_model call 2");
+
+  // Poll until call 2's entry lands (mlock marks it), then check extras.
+  let deadline = std::time::Instant::now() + Duration::from_secs(60);
+  let extras = loop {
+    let s = state_store::load(&state_dir).expect("load state");
+    if let Some(entry) = s.last_params.first() {
+      if entry.params.knobs.mlock == Some(KnobValue::Set(true)) {
+        break entry.params.extras.clone();
+      }
+    }
+    if std::time::Instant::now() > deadline {
+      panic!("call 2 last_params (mlock marker) never persisted");
+    }
+    tokio::time::sleep(Duration::from_millis(40)).await;
+  };
+
+  assert!(
+    extras.is_empty(),
+    "a manual launch with no extras must not inherit call 1's extras; got {extras:?}"
+  );
+
+  let _ = client.call("shutdown", None).await;
+  let _ = timeout(Duration::from_secs(3), daemon).await;
+  std::fs::remove_dir_all(&state).ok();
+  std::fs::remove_dir_all(&model_dir).ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn start_model_returns_error_when_binary_unconfigured() {
   // Production daemon resolves the binary at startup; if it wasn't
   // resolved (e.g. user has no `llama-server` on PATH), `start_model`


### PR DESCRIPTION
When a model is unloaded and reloaded by the proxy auto-start path (e.g. agent switches), free-form argv flags like --chat-template-file were lost because they are persisted in last_params but never read back.

The fix adds an inheritance path for extras similar to how last_params_knobs is already read: if parsed.extras is empty (proxy auto-start sends an empty vec), fall back to the model's last_params extras so free-form flags survive reload cycles.

Build was tested and confirmed to work as expected, there might have been an edge case I'm not smart enough to think of like manual unload discarding the extras upon proxy reload. 