### PR TITLE
fix(unit5): catch a backend declaring one knob id twice

### DIFF
--- a/src/launch/knobs/registry.rs
+++ b/src/launch/knobs/registry.rs
@@ -246,6 +246,14 @@ pub enum RegistryError {
     first: &'static str,
     second: &'static str,
   },
+  /// One backend declares the same id twice. Every id lookup resolves to the
+  /// first match, so the second declaration is unreachable: its ring, concept
+  /// and emit never apply. `KindConflict` only sees a repeat that changes kind,
+  /// and sharing an id *across* backends is deliberate, so neither covers this.
+  DuplicateId {
+    backend: &'static str,
+    id: &'static str,
+  },
 }
 
 impl std::fmt::Display for RegistryError {
@@ -277,6 +285,10 @@ impl std::fmt::Display for RegistryError {
       } => write!(
         f,
         "backend `{backend}` emits `{flag}` from both `{first}` and `{second}`"
+      ),
+      RegistryError::DuplicateId { backend, id } => write!(
+        f,
+        "backend `{backend}` declares knob `{id}` twice; the second is unreachable"
       ),
     }
   }
@@ -345,6 +357,22 @@ fn duplicate_flags(backend_id: &'static str, defs: &[KnobDef]) -> Vec<RegistryEr
   errors
 }
 
+/// One backend declaring an id twice. Shared ids *across* backends are the
+/// point (`distinct_ids` dedupes them), so this is per-backend only.
+fn duplicate_ids(backend_id: &'static str, defs: &[KnobDef]) -> Vec<RegistryError> {
+  let mut errors = Vec::new();
+  let mut seen: BTreeMap<&'static str, ()> = BTreeMap::new();
+  for def in defs {
+    if seen.insert(def.id, ()).is_some() {
+      errors.push(RegistryError::DuplicateId {
+        backend: backend_id,
+        id: def.id,
+      });
+    }
+  }
+  errors
+}
+
 /// Validate the whole registry. Run by a test, so a malformed declaration
 /// fails the build rather than surfacing as a confusing runtime behaviour.
 pub fn validate() -> Vec<RegistryError> {
@@ -400,6 +428,7 @@ pub fn validate() -> Vec<RegistryError> {
 
   for backend in Backends::all() {
     errors.extend(duplicate_flags(backend.id(), backend.knobs()));
+    errors.extend(duplicate_ids(backend.id(), backend.knobs()));
 
     let mut seen: BTreeMap<Concept, usize> = BTreeMap::new();
     for def in backend.knobs() {
@@ -471,6 +500,34 @@ mod tests {
     let errors = duplicate_flags("fake", &defs);
     assert_eq!(errors.len(), 1, "expected one collision, got {errors:?}");
     assert!(errors[0].to_string().contains("--threads"));
+  }
+
+  #[test]
+  fn one_backend_cannot_declare_an_id_twice() {
+    use crate::launch::knobs::def::Emit;
+    // Same id, distinct flags, so `duplicate_flags` sees nothing and the kinds
+    // match, so `KindConflict` sees nothing either.
+    let defs = [
+      flag_def("threads", Some("--threads"), Emit::FlagValue),
+      flag_def("threads", Some("--n-threads"), Emit::FlagValue),
+    ];
+    assert!(
+      duplicate_flags("fake", &defs).is_empty(),
+      "flag check must not be what catches this"
+    );
+    let errors = duplicate_ids("fake", &defs);
+    assert_eq!(errors.len(), 1, "expected one duplicate id, got {errors:?}");
+    assert!(errors[0].to_string().contains("threads"));
+  }
+
+  #[test]
+  fn distinct_ids_in_one_backend_are_not_duplicates() {
+    use crate::launch::knobs::def::Emit;
+    let defs = [
+      flag_def("threads", None, Emit::FlagValue),
+      flag_def("batch-size", None, Emit::FlagValue),
+    ];
+    assert!(duplicate_ids("fake", &defs).is_empty());
   }
 
   #[test]


### PR DESCRIPTION
`validate()` keys its `kinds` map by id across all backends, so a repeat whose kind matches falls through the `Some(_) => {}` arm. Sharing an id across backends is deliberate, so that arm has to stay — but one backend declaring the same id twice reached no check at all, and `duplicate_flags` misses it because two knobs can share an id while emitting different flags. Every lookup resolves to the first match, so the second declaration was silently unreachable: its ring, concept and emit never applied.

This adds `duplicate_ids`, mirroring `duplicate_flags`, in the same per-backend loop, with a `DuplicateId` error and two tests. The main test asserts `duplicate_flags` finds nothing on the same input, so it can only pass because of the new check.

No shipped backend trips it today (`registry_is_valid` passed before and after). It is relevant now because the SGLang knob table (#36) is carrying a local `knob_ids_are_unique` test to cover exactly this gap; once SGLang is registered in `Backends::all()` that local test can go.

Internal validator only — no user-visible behaviour, so no CHANGELOG entry; happy to add one if you'd prefer.

`make test`, `make lint`, knob-parity all green; the change was also mutation-checked (disabling `duplicate_ids` fails `one_backend_cannot_declare_an_id_twice`).
