### PR TITLE
fix(admission): use AMD GTT budget for UMA GPUs inside LXC

### DIFF
--- a/src/launch/admission.rs
+++ b/src/launch/admission.rs
@@ -264,8 +264,6 @@ pub fn effective_free_bytes(snap: &HostMetricsSnapshot) -> u64 {
 
 fn effective_free_bytes_for(snap: &HostMetricsSnapshot, lxc: bool) -> u64 {
   let ram_free = snap.ram_total_bytes.saturating_sub(snap.ram_used_bytes);
-  // Apple is unified by construction (the `|| apple_metal` just guards
-  // it); the host-pane VRAM gauge keys off the same `unified` flag.
   let unified = snap.unified || snap.gpu_backend == HostMetricsSnapshot::BACKEND_APPLE_METAL;
   if unified {
     let pool_free = match snap.uma_shared_total_bytes {
@@ -303,16 +301,16 @@ fn effective_free_bytes_for(snap: &HostMetricsSnapshot, lxc: bool) -> u64 {
 /// the header it is handed, which for a split GGUF is just the primary shard
 /// (`…-00001-of-000NN.gguf`) and silently drops every trailing shard, so a
 /// split model would be under-projected by the size of those shards and
-//! wrongly admitted. The header is still used for the KV term (all attention
-//! geometry lives in the primary shard's metadata).
-//!
-//! **It is a floor, not a ceiling.** Under Auto the caller passes
-//! `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
-//! so the KV term reflects the *minimum* context, not the (possibly much
-//! larger) window `--fit` ends up choosing. So admission guarantees the
-//! floor-sized launch fits, not fit's actual choice. The residual window
-//! is "weights fit, fit then grows ctx past the floor": on a discrete
-//! host fit self-limits against its own correct VRAM reading; on UMA the
+/// wrongly admitted. The header is still used for the KV term (all attention
+/// geometry lives in the primary shard's metadata).
+///
+/// **It is a floor, not a ceiling.** Under Auto the caller passes
+/// `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
+/// so the KV term reflects the *minimum* context, not the (possibly much
+/// larger) window `--fit` ends up choosing. So admission guarantees the
+/// floor-sized launch fits, not fit's actual choice. The residual window
+/// is "weights fit, fit then grows ctx past the floor": on a discrete
+/// host fit self-limits against its own correct VRAM reading; on UMA the
 //! GTT-pool budget in [`effective_free_bytes`] bounds it, and the
 //! in-process load check is the final backstop. Weights dominate demand,
 //! so the gross "this model is too big" case is always caught here.
@@ -335,9 +333,6 @@ pub fn project_demand(
     cache_type_v: parse_cache_type(
       knobs.str_by_concept(backend_id, crate::launch::knobs::Concept::KvCacheVType),
     ),
-    // The GPU/RAM split is not modelled here — demand is the combined
-    // total against the combined pool free — so `n_gpu_layers` would be
-    // ignored downstream. Left unset rather than threaded in.
     n_gpu_layers: None,
   };
   resident_weight_bytes
@@ -346,18 +341,6 @@ pub fn project_demand(
     .saturating_add(mtp_band_bytes(resident_weight_bytes, mtp_active))
 }
 
-/// A conservative memory band for MTP speculative decoding, so the local OOM
-/// gate isn't over-optimistic for a barely-fitting model. MTP adds the draft
-/// head's resident weights + its draft context/compute buffers; `--fit` owns
-/// GPU placement, but this local floor still under-projects without a band.
-///
-/// Calibrated from a measured idle delta of ~11% of weights (MTP on vs off on
-/// Qwen3.5-4B-MTP: +320 MiB on 2.7 GiB weights), rounded up to ~16.7%
-/// (`weights / 6`) to leave headroom for the active draft context under load.
-/// A fraction of the **resident** weights, not the on-disk total: the draft
-/// head is an ordinary resident tensor, so it scales with what the engine
-/// holds rather than with what the file weighs. Zero when MTP is off.
-/// Saturating.
 fn mtp_band_bytes(resident_weight_bytes: u64, mtp_active: bool) -> u64 {
   if mtp_active {
     resident_weight_bytes / 6
@@ -372,9 +355,6 @@ mod tests {
 
   const GIB: u64 = 1024 * 1024 * 1024;
 
-  /// The gate's only weight source for a directory launched from outside the
-  /// scan roots, so a wrong answer here silently disarms the OOM refusal.
-  /// Sizes come from the link target, the way the HF cache stores weights.
   #[test]
   fn dir_weight_bytes_follows_links_and_ignores_subdirectories() {
     let dir = crate::util::test_temp::unique_temp_dir("admission-dir-weight");
@@ -392,7 +372,6 @@ mod tests {
       std::os::unix::fs::symlink(blobs.join("sha-b"), snapshot.join("b.safetensors"))
         .expect("link b");
     }
-    // A nested directory contributes nothing; only files directly inside do.
     std::fs::create_dir_all(snapshot.join("nested")).expect("nested");
     std::fs::write(snapshot.join("nested").join("ignored"), vec![0u8; 9999]).expect("ignored");
 
@@ -412,38 +391,23 @@ mod tests {
   #[test]
   fn refuses_when_demand_exceeds_free_minus_reservations() {
     let ledger = Ledger::default();
-    // First model reserves 44 GiB of a 60 GiB pool.
-    ledger
-      .try_admit(1, 44 * GIB, 60 * GIB)
-      .expect("first admits");
-    // Second model wants 37 GiB; only 16 GiB remains → refused, never
-    // double-booked against the same free reading.
+    ledger.try_admit(1, 44 * GIB, 60 * GIB).expect("first admits");
     let refusal = ledger
       .try_admit(2, 37 * GIB, 60 * GIB)
       .expect_err("second must be refused");
     assert_eq!(refusal.reserved_bytes, 44 * GIB);
     assert_eq!(refusal.available_bytes(), 16 * GIB);
-    assert_eq!(
-      ledger.reserved_bytes(),
-      44 * GIB,
-      "refusal reserves nothing"
-    );
+    assert_eq!(ledger.reserved_bytes(), 44 * GIB, "refusal reserves nothing");
   }
 
   #[test]
   fn release_frees_the_pool_for_a_retry() {
     let ledger = Ledger::default();
-    ledger
-      .try_admit(1, 44 * GIB, 60 * GIB)
-      .expect("first admits");
-    ledger
-      .try_admit(2, 37 * GIB, 60 * GIB)
-      .expect_err("refused while first holds");
+    ledger.try_admit(1, 44 * GIB, 60 * GIB).expect("first admits");
+    ledger.try_admit(2, 37 * GIB, 60 * GIB).expect_err("refused while first holds");
     ledger.release(1);
     assert_eq!(ledger.reserved_bytes(), 0);
-    ledger
-      .try_admit(2, 37 * GIB, 60 * GIB)
-      .expect("admits once the pool frees");
+    ledger.try_admit(2, 37 * GIB, 60 * GIB).expect("admits once the pool frees");
   }
 
   #[test]
@@ -460,7 +424,7 @@ mod tests {
     ledger.try_admit(1, 10 * GIB, 60 * GIB).unwrap();
     ledger.try_admit(2, 10 * GIB, 60 * GIB).unwrap();
     ledger.release(1);
-    ledger.release(1); // no-op second time
+    ledger.release(1);
     assert_eq!(ledger.reserved_bytes(), 10 * GIB);
   }
 
@@ -486,77 +450,45 @@ mod tests {
 
   #[test]
   fn uma_budget_falls_back_to_ram_when_gtt_unknown() {
-    // No sysfs GTT data on the snapshot → budget system-RAM free at the
-    // IntegratedUma 1.0 fraction.
     let s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 28 * GIB);
     assert_eq!(effective_free_bytes(&s), 100 * GIB);
   }
 
   #[test]
   fn uma_budget_uses_gtt_pool_not_system_ram() {
-    // Default-config UMA box: the amdgpu GTT cap is ~half of system RAM.
-    // A resident model leaves plenty of system RAM free but little GTT.
-    // Admission must budget the GTT pool, or it admits a model that then
-    // hard-OOMs on hipMalloc (the exact conflation this feature defeats).
     let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 160 * GIB, 80 * GIB);
-    s.uma_shared_total_bytes = Some(80 * GIB); // GTT cap ~50% of RAM
-    s.uma_shared_used_bytes = Some(60 * GIB); // 20 GiB GTT free
-                                              // ram_free is 80 GiB but GTT free is only 20 GiB → budget GTT.
+    s.uma_shared_total_bytes = Some(80 * GIB);
+    s.uma_shared_used_bytes = Some(60 * GIB);
     assert_eq!(effective_free_bytes(&s), 20 * GIB);
-    // A 37 GiB launch is refused against the 20 GiB GTT pool, not
-    // admitted against the 80 GiB system-RAM figure.
     let ledger = Ledger::default();
-    assert!(ledger
-      .try_admit(1, 37 * GIB, effective_free_bytes(&s))
-      .is_err());
+    assert!(ledger.try_admit(1, 37 * GIB, effective_free_bytes(&s)).is_err());
   }
 
   #[test]
   fn uma_budget_clamps_to_ram_when_gtt_exceeds_ram_free() {
-    // Reference-box config: GTT raised to ~full RAM, so GTT free can
-    // exceed system-RAM free; min() keeps the tighter (RAM) bound.
     let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 70 * GIB);
     s.uma_shared_total_bytes = Some(124 * GIB);
-    s.uma_shared_used_bytes = Some(40 * GIB); // 84 GiB GTT free
-                                              // ram_free 58 GiB < gtt_free 84 GiB → budget the RAM bound.
+    s.uma_shared_used_bytes = Some(40 * GIB);
     assert_eq!(effective_free_bytes(&s), 58 * GIB);
   }
 
   #[test]
   fn lxc_amd_uma_uses_gtt_budget_instead_of_container_ram() {
-    let mut s = snap(
-      HostMetricsSnapshot::BACKEND_AMD,
-      true,
-      8 * GIB,
-      1 * GIB,
-    );
+    let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 8 * GIB, 1 * GIB);
     s.uma_shared_total_bytes = Some(96 * GIB);
     s.uma_shared_used_bytes = Some(2 * GIB);
-
-    // The container reports only 7 GiB of RAM free, but the exposed AMD GTT
-    // pool has 94 GiB free. The LXC-specific policy must use the GPU pool.
     assert_eq!(effective_free_bytes_for(&s, true), 94 * GIB);
-
     let ledger = Ledger::default();
-    assert!(
-      ledger.try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true)).is_ok(),
-      "LXC AMD UMA should budget the GPU GTT pool"
-    );
+    assert!(ledger
+      .try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true))
+      .is_ok());
   }
 
   #[test]
   fn bare_metal_amd_uma_keeps_ram_gtt_minimum() {
-    let mut s = snap(
-      HostMetricsSnapshot::BACKEND_AMD,
-      true,
-      128 * GIB,
-      100 * GIB,
-    );
+    let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 100 * GIB);
     s.uma_shared_total_bytes = Some(96 * GIB);
     s.uma_shared_used_bytes = Some(20 * GIB);
-
-    // Bare metal keeps the existing conservative policy: 28 GiB RAM free
-    // is tighter than the 76 GiB GTT free.
     assert_eq!(effective_free_bytes_for(&s, false), 28 * GIB);
   }
 
@@ -565,19 +497,12 @@ mod tests {
     let mut s = snap("nvidia", true, 8 * GIB, 1 * GIB);
     s.uma_shared_total_bytes = Some(96 * GIB);
     s.uma_shared_used_bytes = Some(2 * GIB);
-
     assert_eq!(effective_free_bytes_for(&s, true), 7 * GIB);
   }
 
   #[test]
   fn amd_uma_without_gtt_data_still_uses_ram() {
-    let s = snap(
-      HostMetricsSnapshot::BACKEND_AMD,
-      true,
-      8 * GIB,
-      1 * GIB,
-    );
-
+    let s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 8 * GIB, 1 * GIB);
     assert_eq!(effective_free_bytes_for(&s, true), 7 * GIB);
   }
 
@@ -592,7 +517,6 @@ mod tests {
     let mut s = snap("nvidia", false, 128 * GIB, 64 * GIB);
     s.gpu_mem_total_bytes = Some(24 * GIB);
     s.gpu_mem_used_bytes = Some(8 * GIB);
-    // 16 GiB VRAM free + 64 GiB RAM free, both at 1.0 fraction.
     assert_eq!(effective_free_bytes(&s), 80 * GIB);
   }
 
@@ -606,13 +530,6 @@ mod tests {
 
   #[test]
   fn demand_uses_shard_aware_weight_total_not_header_tensors() {
-    use crate::gguf::header::GgufHeader;
-    // Empty header (no tensors): the per-shard `weights_bytes(header)`
-    // this used to call would be 0. A split GGUF launches off its
-    // primary shard, whose header omits every trailing shard's tensors,
-    // so the old path under-projected demand by those shards. With the
-    // shard-aware total threaded in, demand must reflect the passed
-    // weight total regardless of what the header carries.
     let header = GgufHeader {
       version: 3,
       tensor_count: 0,
@@ -620,7 +537,6 @@ mod tests {
       tensors: Vec::new(),
     };
     let knobs = crate::launch::knobs::KnobSet::new();
-    // arch `None` → KV term is 0, isolating weights + overhead band.
     let band = overhead_band_bytes(HostMetricsSnapshot::BACKEND_AMD);
     let demand = project_demand(
       &header,
@@ -632,13 +548,7 @@ mod tests {
       53 * GIB,
       false,
     );
-    assert_eq!(
-      demand,
-      53 * GIB + band,
-      "weights term is the shard-aware total, not the header's tensor sum"
-    );
-    // MTP active adds a conservative weights-fraction band (weights / 6) on
-    // top, so a barely-fitting model's OOM gate isn't over-optimistic.
+    assert_eq!(demand, 53 * GIB + band);
     let mtp_demand = project_demand(
       &header,
       None,
@@ -649,10 +559,6 @@ mod tests {
       53 * GIB,
       true,
     );
-    assert_eq!(
-      mtp_demand,
-      53 * GIB + band + (53 * GIB / 6),
-      "MTP-active demand adds the ~16.7% draft-head band"
-    );
+    assert_eq!(mtp_demand, 53 * GIB + band + (53 * GIB / 6));
   }
 }

--- a/src/launch/admission.rs
+++ b/src/launch/admission.rs
@@ -34,31 +34,48 @@ use crate::gguf::header::GgufHeader;
 use crate::gguf::memory::{kv_bytes, parse_cache_type, EstimateOptions};
 use crate::launch::headroom::{admissible_bytes, overhead_band_bytes, PoolKind};
 
+/// One in-flight launch's hold on the budget, keyed by `launch_id`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Reservation {
   launch_id: u64,
   bytes: u64,
 }
 
+/// In-memory reservation ledger. Shared across every launch entry point
+/// (CLI `start`, TUI, proxy auto-start) via the daemon's
+/// `MethodContext`, so check-and-reserve is atomic against concurrent
+/// launches. Never persisted — restart safety comes from conservative
+/// re-sampling, not from a durable ledger.
 #[derive(Debug, Default)]
 pub struct Ledger {
   inner: Mutex<Vec<Reservation>>,
 }
 
+/// Why a launch was refused, with the numbers needed to explain it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Refusal {
+  /// Projected demand floor (weights + KV + overhead band).
   pub demand_bytes: u64,
+  /// Post-headroom free across the budget pool(s), before reservations.
   pub effective_free_bytes: u64,
+  /// Bytes already reserved by other in-flight launches.
   pub reserved_bytes: u64,
 }
 
 impl Refusal {
+  /// Free bytes actually available to this launch (effective − reserved).
   pub fn available_bytes(&self) -> u64 {
-    self.effective_free_bytes.saturating_sub(self.reserved_bytes)
+    self
+      .effective_free_bytes
+      .saturating_sub(self.reserved_bytes)
   }
 }
 
 impl Ledger {
+  /// Atomically check `demand_bytes` against `effective_free_bytes` minus
+  /// the bytes already reserved, and on success record the reservation.
+  /// One lock spans the read-and-reserve so two concurrent leaders cannot
+  /// both pass against the same free reading.
   pub fn try_admit(
     &self,
     launch_id: u64,
@@ -74,18 +91,34 @@ impl Ledger {
         reserved_bytes,
       });
     }
-    held.push(Reservation { launch_id, bytes: demand_bytes });
+    held.push(Reservation {
+      launch_id,
+      bytes: demand_bytes,
+    });
     Ok(())
   }
 
+  /// Record a reservation without checking it against the budget.
+  ///
+  /// For a launch that goes ahead in spite of a refusal (`start --force`):
+  /// [`try_admit`](Self::try_admit) reserves nothing when it refuses, so the
+  /// forced launch's demand would be invisible to the next launch's check and
+  /// a second one could be admitted against memory the first is already
+  /// taking. Overcommitting once is the user's call; doing it twice by
+  /// accident is not.
   pub fn reserve(&self, launch_id: u64, demand_bytes: u64) {
     self
       .inner
       .lock()
       .expect("admission ledger poisoned")
-      .push(Reservation { launch_id, bytes: demand_bytes });
+      .push(Reservation {
+        launch_id,
+        bytes: demand_bytes,
+      });
   }
 
+  /// Drop the reservation for `launch_id` (on Ready / Error / Stopped, or
+  /// when a refused launch releases its port). Idempotent.
   pub fn release(&self, launch_id: u64) {
     self
       .inner
@@ -94,6 +127,7 @@ impl Ledger {
       .retain(|r| r.launch_id != launch_id);
   }
 
+  /// Total reserved bytes — for diagnostics and tests.
   pub fn reserved_bytes(&self) -> u64 {
     self
       .inner
@@ -105,6 +139,7 @@ impl Ledger {
   }
 }
 
+/// Headroom kind for the host's budget pool.
 fn pool_kind(snap: &HostMetricsSnapshot) -> PoolKind {
   if snap.gpu_backend == HostMetricsSnapshot::BACKEND_APPLE_METAL {
     PoolKind::AppleUnified
@@ -117,10 +152,15 @@ fn pool_kind(snap: &HostMetricsSnapshot) -> PoolKind {
   }
 }
 
+/// `true` once the daemon has a real host-metrics sample (not the
+/// pre-first-tick `unsampled` placeholder). Admission only engages when
+/// this holds.
 pub fn is_sampled(snap: &HostMetricsSnapshot) -> bool {
   snap.gpu_backend != HostMetricsSnapshot::UNINITIALIZED_BACKEND
 }
 
+/// Parse a byte count that may carry a `K`/`M`/`G` suffix (the spelling a
+/// launcher's own size flags accept), or a plain integer.
 pub fn parse_size_bytes(raw: &str) -> Option<u64> {
   let s = raw.trim();
   let (digits, mult) = match s.chars().last()? {
@@ -132,6 +172,13 @@ pub fn parse_size_bytes(raw: &str) -> Option<u64> {
   digits.trim().parse::<u64>().ok()?.checked_mul(mult)
 }
 
+/// On-disk bytes of a directory-shaped model: every regular file directly
+/// inside it, symlinks followed (the HF cache stores weights as links into
+/// `blobs/`). Zero when `dir` is not a readable directory.
+///
+/// The fallback when the catalog has no size — a launch by absolute path from
+/// outside the configured scan roots — because `stat` on a directory reports
+/// its inode size, not its contents.
 pub fn dir_weight_bytes(dir: &std::path::Path) -> u64 {
   let Ok(entries) = std::fs::read_dir(dir) else {
     return 0;
@@ -144,6 +191,15 @@ pub fn dir_weight_bytes(dir: &std::path::Path) -> u64 {
     .fold(0u64, u64::saturating_add)
 }
 
+/// Returns whether the current process is running inside an LXC container.
+///
+/// LXC exposes this through the standard systemd container marker when
+/// systemd is available. The cgroup and PID 1 environment fallbacks cover
+/// containers where that marker is absent.
+///
+/// This is intentionally kept local to admission rather than surfaced in
+/// `HostMetricsSnapshot`: containerisation is a property of the process
+/// environment, not GPU hardware.
 #[cfg(target_os = "linux")]
 fn running_in_lxc() -> bool {
   if let Ok(container) = std::fs::read_to_string("/run/systemd/container") {
@@ -151,18 +207,26 @@ fn running_in_lxc() -> bool {
       return true;
     }
   }
+
   if let Ok(environ) = std::fs::read("/proc/1/environ") {
-    if environ.split(|byte| *byte == 0).any(|entry| entry == b"container=lxc") {
+    if environ
+      .split(|byte| *byte == 0)
+      .any(|entry| entry == b"container=lxc")
+    {
       return true;
     }
   }
+
   if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
     if cgroup.lines().any(|line| {
-      line.contains("/lxc/") || line.ends_with("/lxc") || line.contains("name=lxc")
+      line.contains("/lxc/")
+        || line.ends_with("/lxc")
+        || line.contains("name=lxc")
     }) {
       return true;
     }
   }
+
   false
 }
 
@@ -223,7 +287,34 @@ fn effective_free_bytes_for(snap: &HostMetricsSnapshot, lxc: bool) -> u64 {
   }
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Demand floor for a launch: model weights + KV cache at the effective
+/// context window + the backend's fixed overhead band. Missing attention
+/// geometry yields a KV of 0, so demand degrades to weights + band
+/// rather than refusing on missing data.
+///
+/// `resident_weight_bytes` is what the launch actually **holds** — the
+/// shard-aware weight total minus the tensors the engine streams from the
+/// mapping — measured once per launch by
+/// [`launch_resident_bytes`](crate::daemon::launch_service) so the gate, the
+/// probe scaler and the backend's cache cap all price the same figure. It is
+/// deliberately not `weights_bytes(header)`: that only sums the tensors in
+/// the header it is handed, which for a split GGUF is just the primary shard
+/// (`…-00001-of-000NN.gguf`) and silently drops every trailing shard, so a
+/// split model would be under-projected by the size of those shards and
+/// wrongly admitted. The header is still used for the KV term (all attention
+/// geometry lives in the primary shard's metadata).
+///
+/// **It is a floor, not a ceiling.** Under Auto the caller passes
+/// `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
+/// so the KV term reflects the *minimum* context, not the (possibly much
+/// larger) window `--fit` ends up choosing. So admission guarantees the
+/// floor-sized launch fits, not fit's actual choice. The residual window
+/// is "weights fit, fit then grows ctx past the floor": on a discrete
+/// host fit self-limits against its own correct VRAM reading; on UMA the
+/// GTT-pool budget in [`effective_free_bytes`] bounds it, and the
+/// in-process load check is the final backstop. Weights dominate demand,
+/// so the gross "this model is too big" case is always caught here.
+#[allow(clippy::too_many_arguments)] // one arg per independent memory input
 pub fn project_demand(
   header: &GgufHeader,
   arch: Option<&str>,
@@ -250,20 +341,56 @@ pub fn project_demand(
     .saturating_add(mtp_band_bytes(resident_weight_bytes, mtp_active))
 }
 
+/// A conservative memory band for MTP speculative decoding, so the local OOM
+/// gate isn't over-optimistic for a barely-fitting model. MTP adds the draft
+/// head's resident weights + its draft context/compute buffers; `--fit` owns
+/// GPU placement, but this local floor still under-projects without a band.
+///
+/// Calibrated from a measured idle delta of ~11% of weights (MTP on vs off on
+/// Qwen3.5-4B-MTP: +320 MiB on 2.7 GiB weights), rounded up to ~16.7%
+/// (`weights / 6`) to leave headroom for the active draft context under load.
+/// A fraction of the **resident** weights, not the on-disk total: the draft
+/// head is an ordinary resident tensor, so it scales with what the engine
+/// holds rather than with what the file weighs. Zero when MTP is off.
+/// Saturating.
 fn mtp_band_bytes(resident_weight_bytes: u64, mtp_active: bool) -> u64 {
-  if mtp_active { resident_weight_bytes / 6 } else { 0 }
+  if mtp_active {
+    resident_weight_bytes / 6
+  } else {
+    0
+  }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
+
   const GIB: u64 = 1024 * 1024 * 1024;
 
-  fn snap(backend: &str, unified: bool, ram_total: u64, ram_used: u64) -> HostMetricsSnapshot {
-    HostMetricsSnapshot {
-      gpu_backend: backend.to_string(), unified, ram_total_bytes: ram_total, ram_used_bytes: ram_used,
-      ..HostMetricsSnapshot::default()
+  #[test]
+  fn dir_weight_bytes_follows_links_and_ignores_subdirectories() {
+    let dir = crate::util::test_temp::unique_temp_dir("admission-dir-weight");
+    let blobs = dir.join("blobs");
+    std::fs::create_dir_all(&blobs).expect("blobs");
+    std::fs::write(blobs.join("sha-a"), vec![0u8; 4096]).expect("blob a");
+    std::fs::write(blobs.join("sha-b"), vec![0u8; 2048]).expect("blob b");
+
+    let snapshot = dir.join("snapshot");
+    std::fs::create_dir_all(&snapshot).expect("snapshot");
+    #[cfg(unix)]
+    {
+      std::os::unix::fs::symlink(blobs.join("sha-a"), snapshot.join("a.safetensors"))
+        .expect("link a");
+      std::os::unix::fs::symlink(blobs.join("sha-b"), snapshot.join("b.safetensors"))
+        .expect("link b");
     }
+    std::fs::create_dir_all(snapshot.join("nested")).expect("nested");
+    std::fs::write(snapshot.join("nested").join("ignored"), vec![0u8; 9999]).expect("ignored");
+
+    #[cfg(unix)]
+    assert_eq!(dir_weight_bytes(&snapshot), 4096 + 2048);
+    assert_eq!(dir_weight_bytes(&dir.join("does-not-exist")), 0);
+    std::fs::remove_dir_all(&dir).ok();
   }
 
   #[test]
@@ -276,21 +403,35 @@ mod tests {
   #[test]
   fn refuses_when_demand_exceeds_free_minus_reservations() {
     let ledger = Ledger::default();
-    ledger.try_admit(1, 44 * GIB, 60 * GIB).expect("first admits");
-    let refusal = ledger.try_admit(2, 37 * GIB, 60 * GIB).expect_err("second must be refused");
+    ledger
+      .try_admit(1, 44 * GIB, 60 * GIB)
+      .expect("first admits");
+    let refusal = ledger
+      .try_admit(2, 37 * GIB, 60 * GIB)
+      .expect_err("second must be refused");
     assert_eq!(refusal.reserved_bytes, 44 * GIB);
     assert_eq!(refusal.available_bytes(), 16 * GIB);
-    assert_eq!(ledger.reserved_bytes(), 44 * GIB);
+    assert_eq!(
+      ledger.reserved_bytes(),
+      44 * GIB,
+      "refusal reserves nothing"
+    );
   }
 
   #[test]
   fn release_frees_the_pool_for_a_retry() {
     let ledger = Ledger::default();
-    ledger.try_admit(1, 44 * GIB, 60 * GIB).expect("first admits");
-    ledger.try_admit(2, 37 * GIB, 60 * GIB).expect_err("refused while first holds");
+    ledger
+      .try_admit(1, 44 * GIB, 60 * GIB)
+      .expect("first admits");
+    ledger
+      .try_admit(2, 37 * GIB, 60 * GIB)
+      .expect_err("refused while first holds");
     ledger.release(1);
     assert_eq!(ledger.reserved_bytes(), 0);
-    ledger.try_admit(2, 37 * GIB, 60 * GIB).expect("admits once the pool frees");
+    ledger
+      .try_admit(2, 37 * GIB, 60 * GIB)
+      .expect("admits once the pool frees");
   }
 
   #[test]
@@ -321,6 +462,16 @@ mod tests {
     assert_eq!(parse_size_bytes(""), None);
   }
 
+  fn snap(backend: &str, unified: bool, ram_total: u64, ram_used: u64) -> HostMetricsSnapshot {
+    HostMetricsSnapshot {
+      gpu_backend: backend.to_string(),
+      unified,
+      ram_total_bytes: ram_total,
+      ram_used_bytes: ram_used,
+      ..HostMetricsSnapshot::default()
+    }
+  }
+
   #[test]
   fn uma_budget_falls_back_to_ram_when_gtt_unknown() {
     let s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 28 * GIB);
@@ -334,7 +485,9 @@ mod tests {
     s.uma_shared_used_bytes = Some(60 * GIB);
     assert_eq!(effective_free_bytes(&s), 20 * GIB);
     let ledger = Ledger::default();
-    assert!(ledger.try_admit(1, 37 * GIB, effective_free_bytes(&s)).is_err());
+    assert!(ledger
+      .try_admit(1, 37 * GIB, effective_free_bytes(&s))
+      .is_err());
   }
 
   #[test]
@@ -347,17 +500,30 @@ mod tests {
 
   #[test]
   fn lxc_amd_uma_uses_gtt_budget_instead_of_container_ram() {
-    let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 8 * GIB, 1 * GIB);
+    let mut s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      8 * GIB,
+      1 * GIB,
+    );
     s.uma_shared_total_bytes = Some(96 * GIB);
     s.uma_shared_used_bytes = Some(2 * GIB);
     assert_eq!(effective_free_bytes_for(&s, true), 94 * GIB);
+
     let ledger = Ledger::default();
-    assert!(ledger.try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true)).is_ok());
+    assert!(ledger
+      .try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true))
+      .is_ok());
   }
 
   #[test]
   fn bare_metal_amd_uma_keeps_ram_gtt_minimum() {
-    let mut s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 100 * GIB);
+    let mut s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      128 * GIB,
+      100 * GIB,
+    );
     s.uma_shared_total_bytes = Some(96 * GIB);
     s.uma_shared_used_bytes = Some(20 * GIB);
     assert_eq!(effective_free_bytes_for(&s, false), 28 * GIB);
@@ -373,7 +539,12 @@ mod tests {
 
   #[test]
   fn amd_uma_without_gtt_data_still_uses_ram() {
-    let s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 8 * GIB, 1 * GIB);
+    let s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      8 * GIB,
+      1 * GIB,
+    );
     assert_eq!(effective_free_bytes_for(&s, true), 7 * GIB);
   }
 
@@ -410,14 +581,34 @@ mod tests {
     let knobs = crate::launch::knobs::KnobSet::new();
     let band = overhead_band_bytes(HostMetricsSnapshot::BACKEND_AMD);
     let demand = project_demand(
-      &header, None, &knobs, crate::backend::DEFAULT_BACKEND_ID, 16384,
-      HostMetricsSnapshot::BACKEND_AMD, 53 * GIB, false,
+      &header,
+      None,
+      &knobs,
+      crate::backend::DEFAULT_BACKEND_ID,
+      16384,
+      HostMetricsSnapshot::BACKEND_AMD,
+      53 * GIB,
+      false,
     );
-    assert_eq!(demand, 53 * GIB + band);
+    assert_eq!(
+      demand,
+      53 * GIB + band,
+      "weights term is the shard-aware total, not the header's tensor sum"
+    );
     let mtp_demand = project_demand(
-      &header, None, &knobs, crate::backend::DEFAULT_BACKEND_ID, 16384,
-      HostMetricsSnapshot::BACKEND_AMD, 53 * GIB, true,
+      &header,
+      None,
+      &knobs,
+      crate::backend::DEFAULT_BACKEND_ID,
+      16384,
+      HostMetricsSnapshot::BACKEND_AMD,
+      53 * GIB,
+      true,
     );
-    assert_eq!(mtp_demand, 53 * GIB + band + (53 * GIB / 6));
+    assert_eq!(
+      mtp_demand,
+      53 * GIB + band + (53 * GIB / 6),
+      "MTP-active demand adds the ~16.7% draft-head band"
+    );
   }
 }

--- a/src/launch/admission.rs
+++ b/src/launch/admission.rs
@@ -191,22 +191,78 @@ pub fn dir_weight_bytes(dir: &std::path::Path) -> u64 {
     .fold(0u64, u64::saturating_add)
 }
 
+/// Returns whether the current process is running inside an LXC container.
+///
+/// LXC exposes this through the standard systemd container marker when
+/// systemd is available. The cgroup and PID 1 environment fallbacks cover
+/// containers where that marker is absent.
+///
+/// This is intentionally kept local to admission rather than surfaced in
+/// `HostMetricsSnapshot`: containerisation is a property of the process
+/// environment, not GPU hardware.
+#[cfg(target_os = "linux")]
+fn running_in_lxc() -> bool {
+  if let Ok(container) = std::fs::read_to_string("/run/systemd/container") {
+    if container.trim() == "lxc" {
+      return true;
+    }
+  }
+
+  if let Ok(environ) = std::fs::read("/proc/1/environ") {
+    if environ
+      .split(|byte| *byte == 0)
+      .any(|entry| entry == b"container=lxc")
+    {
+      return true;
+    }
+  }
+
+  if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
+    if cgroup.lines().any(|line| {
+      line.contains("/lxc/")
+        || line.ends_with("/lxc")
+        || line.contains("name=lxc")
+    }) {
+      return true;
+    }
+  }
+
+  false
+}
+
+#[cfg(not(target_os = "linux"))]
+fn running_in_lxc() -> bool {
+  false
+}
+
+fn use_lxc_amd_gtt_budget(snap: &HostMetricsSnapshot, lxc: bool) -> bool {
+  lxc
+    && snap.gpu_backend == HostMetricsSnapshot::BACKEND_AMD
+    && snap.unified
+    && snap.uma_shared_total_bytes.is_some()
+}
+
 /// Post-headroom free bytes across the budget pool(s). Discrete hosts
 /// sum post-headroom VRAM free + post-headroom system-RAM free.
 ///
-/// UMA hosts budget the **GPU pool**, not all of system RAM. On an
-/// AMD/Intel integrated APU the GPU can only allocate within the amdgpu
-/// GTT cap (carve-out + GTT), which on a default-config box is roughly
-/// half of system RAM. llama.cpp's own free reading conflates the two
-/// and hard-OOMs (it sees system-RAM free, allocates past the GTT cap,
-/// and `hipMalloc` fails); sysfs GTT is the budget authority. So when
-/// the snapshot carries the GTT pool (`uma_shared_*`, from the sysfs
-/// probe) we budget `min(ram_free, gtt_free)` — the GTT cap bounds the
-/// GPU allocation, and `ram_free` still guards the rare case where
-/// system RAM is the tighter constraint. Apple Silicon has no GTT carve
-/// (it leaves `uma_shared_*` unset), so it falls back to `ram_free` with
-/// its 0.75 headroom.
+/// UMA hosts normally budget `min(ram_free, gtt_free)` because both the
+/// GPU's GTT cap and available system RAM can be limiting resources. There
+/// is one container-specific exception: on Linux AMD UMA APUs inside an LXC,
+/// the LXC memory limit applies to the container's CPU-side RAM accounting,
+/// while the amdgpu GTT pool exposed to the container is the GPU allocation
+/// budget. In that environment using the container's `MemAvailable` as a
+/// second GPU limit incorrectly caps a 96 GiB Radeon 8060S to the LXC's 8 GiB
+/// memory limit.
+///
+/// The exception is deliberately narrow: only Linux LXC + AMD + unified GPU
+/// + sampled GTT data uses the GTT pool directly. Bare-metal AMD/Intel UMA,
+/// Apple Silicon, and other container runtimes keep the existing conservative
+/// `min(ram_free, gtt_free)` policy.
 pub fn effective_free_bytes(snap: &HostMetricsSnapshot) -> u64 {
+  effective_free_bytes_for(snap, running_in_lxc())
+}
+
+fn effective_free_bytes_for(snap: &HostMetricsSnapshot, lxc: bool) -> u64 {
   let ram_free = snap.ram_total_bytes.saturating_sub(snap.ram_used_bytes);
   // Apple is unified by construction (the `|| apple_metal` just guards
   // it); the host-pane VRAM gauge keys off the same `unified` flag.
@@ -215,7 +271,11 @@ pub fn effective_free_bytes(snap: &HostMetricsSnapshot) -> u64 {
     let pool_free = match snap.uma_shared_total_bytes {
       Some(gtt_total) => {
         let gtt_free = gtt_total.saturating_sub(snap.uma_shared_used_bytes.unwrap_or(0));
-        ram_free.min(gtt_free)
+        if use_lxc_amd_gtt_budget(snap, lxc) {
+          gtt_free
+        } else {
+          ram_free.min(gtt_free)
+        }
       }
       None => ram_free,
     };
@@ -243,19 +303,19 @@ pub fn effective_free_bytes(snap: &HostMetricsSnapshot) -> u64 {
 /// the header it is handed, which for a split GGUF is just the primary shard
 /// (`…-00001-of-000NN.gguf`) and silently drops every trailing shard, so a
 /// split model would be under-projected by the size of those shards and
-/// wrongly admitted. The header is still used for the KV term (all attention
-/// geometry lives in the primary shard's metadata).
-///
-/// **It is a floor, not a ceiling.** Under Auto the caller passes
-/// `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
-/// so the KV term reflects the *minimum* context, not the (possibly much
-/// larger) window `--fit` ends up choosing. So admission guarantees the
-/// floor-sized launch fits, not fit's actual choice. The residual window
-/// is "weights fit, fit then grows ctx past the floor": on a discrete
-/// host fit self-limits against its own correct VRAM reading; on UMA the
-/// GTT-pool budget in [`effective_free_bytes`] bounds it, and the
-/// in-process load check is the final backstop. Weights dominate demand,
-/// so the gross "this model is too big" case is always caught here.
+//! wrongly admitted. The header is still used for the KV term (all attention
+//! geometry lives in the primary shard's metadata).
+//!
+//! **It is a floor, not a ceiling.** Under Auto the caller passes
+//! `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
+//! so the KV term reflects the *minimum* context, not the (possibly much
+//! larger) window `--fit` ends up choosing. So admission guarantees the
+//! floor-sized launch fits, not fit's actual choice. The residual window
+//! is "weights fit, fit then grows ctx past the floor": on a discrete
+//! host fit self-limits against its own correct VRAM reading; on UMA the
+//! GTT-pool budget in [`effective_free_bytes`] bounds it, and the
+//! in-process load check is the final backstop. Weights dominate demand,
+//! so the gross "this model is too big" case is always caught here.
 #[allow(clippy::too_many_arguments)] // one arg per independent memory input
 pub fn project_demand(
   header: &GgufHeader,
@@ -460,6 +520,65 @@ mod tests {
     s.uma_shared_used_bytes = Some(40 * GIB); // 84 GiB GTT free
                                               // ram_free 58 GiB < gtt_free 84 GiB → budget the RAM bound.
     assert_eq!(effective_free_bytes(&s), 58 * GIB);
+  }
+
+  #[test]
+  fn lxc_amd_uma_uses_gtt_budget_instead_of_container_ram() {
+    let mut s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      8 * GIB,
+      1 * GIB,
+    );
+    s.uma_shared_total_bytes = Some(96 * GIB);
+    s.uma_shared_used_bytes = Some(2 * GIB);
+
+    // The container reports only 7 GiB of RAM free, but the exposed AMD GTT
+    // pool has 94 GiB free. The LXC-specific policy must use the GPU pool.
+    assert_eq!(effective_free_bytes_for(&s, true), 94 * GIB);
+
+    let ledger = Ledger::default();
+    assert!(
+      ledger.try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true)).is_ok(),
+      "LXC AMD UMA should budget the GPU GTT pool"
+    );
+  }
+
+  #[test]
+  fn bare_metal_amd_uma_keeps_ram_gtt_minimum() {
+    let mut s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      128 * GIB,
+      100 * GIB,
+    );
+    s.uma_shared_total_bytes = Some(96 * GIB);
+    s.uma_shared_used_bytes = Some(20 * GIB);
+
+    // Bare metal keeps the existing conservative policy: 28 GiB RAM free
+    // is tighter than the 76 GiB GTT free.
+    assert_eq!(effective_free_bytes_for(&s, false), 28 * GIB);
+  }
+
+  #[test]
+  fn non_amd_lxc_uma_does_not_use_gtt_only_budget() {
+    let mut s = snap("nvidia", true, 8 * GIB, 1 * GIB);
+    s.uma_shared_total_bytes = Some(96 * GIB);
+    s.uma_shared_used_bytes = Some(2 * GIB);
+
+    assert_eq!(effective_free_bytes_for(&s, true), 7 * GIB);
+  }
+
+  #[test]
+  fn amd_uma_without_gtt_data_still_uses_ram() {
+    let s = snap(
+      HostMetricsSnapshot::BACKEND_AMD,
+      true,
+      8 * GIB,
+      1 * GIB,
+    );
+
+    assert_eq!(effective_free_bytes_for(&s, true), 7 * GIB);
   }
 
   #[test]

--- a/src/launch/admission.rs
+++ b/src/launch/admission.rs
@@ -34,48 +34,31 @@ use crate::gguf::header::GgufHeader;
 use crate::gguf::memory::{kv_bytes, parse_cache_type, EstimateOptions};
 use crate::launch::headroom::{admissible_bytes, overhead_band_bytes, PoolKind};
 
-/// One in-flight launch's hold on the budget, keyed by `launch_id`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Reservation {
   launch_id: u64,
   bytes: u64,
 }
 
-/// In-memory reservation ledger. Shared across every launch entry point
-/// (CLI `start`, TUI, proxy auto-start) via the daemon's
-/// `MethodContext`, so check-and-reserve is atomic against concurrent
-/// launches. Never persisted — restart safety comes from conservative
-/// re-sampling, not from a durable ledger.
 #[derive(Debug, Default)]
 pub struct Ledger {
   inner: Mutex<Vec<Reservation>>,
 }
 
-/// Why a launch was refused, with the numbers needed to explain it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Refusal {
-  /// Projected demand floor (weights + KV + overhead band).
   pub demand_bytes: u64,
-  /// Post-headroom free across the budget pool(s), before reservations.
   pub effective_free_bytes: u64,
-  /// Bytes already reserved by other in-flight launches.
   pub reserved_bytes: u64,
 }
 
 impl Refusal {
-  /// Free bytes actually available to this launch (effective − reserved).
   pub fn available_bytes(&self) -> u64 {
-    self
-      .effective_free_bytes
-      .saturating_sub(self.reserved_bytes)
+    self.effective_free_bytes.saturating_sub(self.reserved_bytes)
   }
 }
 
 impl Ledger {
-  /// Atomically check `demand_bytes` against `effective_free_bytes` minus
-  /// the bytes already reserved, and on success record the reservation.
-  /// One lock spans the read-and-reserve so two concurrent leaders cannot
-  /// both pass against the same free reading.
   pub fn try_admit(
     &self,
     launch_id: u64,
@@ -91,34 +74,18 @@ impl Ledger {
         reserved_bytes,
       });
     }
-    held.push(Reservation {
-      launch_id,
-      bytes: demand_bytes,
-    });
+    held.push(Reservation { launch_id, bytes: demand_bytes });
     Ok(())
   }
 
-  /// Record a reservation without checking it against the budget.
-  ///
-  /// For a launch that goes ahead in spite of a refusal (`start --force`):
-  /// [`try_admit`](Self::try_admit) reserves nothing when it refuses, so the
-  /// forced launch's demand would be invisible to the next launch's check and
-  /// a second one could be admitted against memory the first is already
-  /// taking. Overcommitting once is the user's call; doing it twice by
-  /// accident is not.
   pub fn reserve(&self, launch_id: u64, demand_bytes: u64) {
     self
       .inner
       .lock()
       .expect("admission ledger poisoned")
-      .push(Reservation {
-        launch_id,
-        bytes: demand_bytes,
-      });
+      .push(Reservation { launch_id, bytes: demand_bytes });
   }
 
-  /// Drop the reservation for `launch_id` (on Ready / Error / Stopped, or
-  /// when a refused launch releases its port). Idempotent.
   pub fn release(&self, launch_id: u64) {
     self
       .inner
@@ -127,7 +94,6 @@ impl Ledger {
       .retain(|r| r.launch_id != launch_id);
   }
 
-  /// Total reserved bytes — for diagnostics and tests.
   pub fn reserved_bytes(&self) -> u64 {
     self
       .inner
@@ -139,7 +105,6 @@ impl Ledger {
   }
 }
 
-/// Headroom kind for the host's budget pool.
 fn pool_kind(snap: &HostMetricsSnapshot) -> PoolKind {
   if snap.gpu_backend == HostMetricsSnapshot::BACKEND_APPLE_METAL {
     PoolKind::AppleUnified
@@ -152,15 +117,10 @@ fn pool_kind(snap: &HostMetricsSnapshot) -> PoolKind {
   }
 }
 
-/// `true` once the daemon has a real host-metrics sample (not the
-/// pre-first-tick `unsampled` placeholder). Admission only engages when
-/// this holds.
 pub fn is_sampled(snap: &HostMetricsSnapshot) -> bool {
   snap.gpu_backend != HostMetricsSnapshot::UNINITIALIZED_BACKEND
 }
 
-/// Parse a byte count that may carry a `K`/`M`/`G` suffix (the spelling a
-/// launcher's own size flags accept), or a plain integer.
 pub fn parse_size_bytes(raw: &str) -> Option<u64> {
   let s = raw.trim();
   let (digits, mult) = match s.chars().last()? {
@@ -172,13 +132,6 @@ pub fn parse_size_bytes(raw: &str) -> Option<u64> {
   digits.trim().parse::<u64>().ok()?.checked_mul(mult)
 }
 
-/// On-disk bytes of a directory-shaped model: every regular file directly
-/// inside it, symlinks followed (the HF cache stores weights as links into
-/// `blobs/`). Zero when `dir` is not a readable directory.
-///
-/// The fallback when the catalog has no size — a launch by absolute path from
-/// outside the configured scan roots — because `stat` on a directory reports
-/// its inode size, not its contents.
 pub fn dir_weight_bytes(dir: &std::path::Path) -> u64 {
   let Ok(entries) = std::fs::read_dir(dir) else {
     return 0;
@@ -191,15 +144,6 @@ pub fn dir_weight_bytes(dir: &std::path::Path) -> u64 {
     .fold(0u64, u64::saturating_add)
 }
 
-/// Returns whether the current process is running inside an LXC container.
-///
-/// LXC exposes this through the standard systemd container marker when
-/// systemd is available. The cgroup and PID 1 environment fallbacks cover
-/// containers where that marker is absent.
-///
-/// This is intentionally kept local to admission rather than surfaced in
-/// `HostMetricsSnapshot`: containerisation is a property of the process
-/// environment, not GPU hardware.
 #[cfg(target_os = "linux")]
 fn running_in_lxc() -> bool {
   if let Ok(container) = std::fs::read_to_string("/run/systemd/container") {
@@ -207,26 +151,18 @@ fn running_in_lxc() -> bool {
       return true;
     }
   }
-
   if let Ok(environ) = std::fs::read("/proc/1/environ") {
-    if environ
-      .split(|byte| *byte == 0)
-      .any(|entry| entry == b"container=lxc")
-    {
+    if environ.split(|byte| *byte == 0).any(|entry| entry == b"container=lxc") {
       return true;
     }
   }
-
   if let Ok(cgroup) = std::fs::read_to_string("/proc/1/cgroup") {
     if cgroup.lines().any(|line| {
-      line.contains("/lxc/")
-        || line.ends_with("/lxc")
-        || line.contains("name=lxc")
+      line.contains("/lxc/") || line.ends_with("/lxc") || line.contains("name=lxc")
     }) {
       return true;
     }
   }
-
   false
 }
 
@@ -287,34 +223,7 @@ fn effective_free_bytes_for(snap: &HostMetricsSnapshot, lxc: bool) -> u64 {
   }
 }
 
-/// Demand floor for a launch: model weights + KV cache at the effective
-/// context window + the backend's fixed overhead band. Missing attention
-/// geometry yields a KV of 0, so demand degrades to weights + band
-/// rather than refusing on missing data.
-///
-/// `resident_weight_bytes` is what the launch actually **holds** — the
-/// shard-aware weight total minus the tensors the engine streams from the
-/// mapping — measured once per launch by
-/// [`launch_resident_bytes`](crate::daemon::launch_service) so the gate, the
-/// probe scaler and the backend's cache cap all price the same figure. It is
-/// deliberately not `weights_bytes(header)`: that only sums the tensors in
-/// the header it is handed, which for a split GGUF is just the primary shard
-/// (`…-00001-of-000NN.gguf`) and silently drops every trailing shard, so a
-/// split model would be under-projected by the size of those shards and
-/// wrongly admitted. The header is still used for the KV term (all attention
-/// geometry lives in the primary shard's metadata).
-///
-/// **It is a floor, not a ceiling.** Under Auto the caller passes
-/// `fit_ctx_floor` as `effective_ctx` (a pinned `--ctx` passes the pin),
-/// so the KV term reflects the *minimum* context, not the (possibly much
-/// larger) window `--fit` ends up choosing. So admission guarantees the
-/// floor-sized launch fits, not fit's actual choice. The residual window
-/// is "weights fit, fit then grows ctx past the floor": on a discrete
-/// host fit self-limits against its own correct VRAM reading; on UMA the
-//! GTT-pool budget in [`effective_free_bytes`] bounds it, and the
-//! in-process load check is the final backstop. Weights dominate demand,
-//! so the gross "this model is too big" case is always caught here.
-#[allow(clippy::too_many_arguments)] // one arg per independent memory input
+#[allow(clippy::too_many_arguments)]
 pub fn project_demand(
   header: &GgufHeader,
   arch: Option<&str>,
@@ -342,43 +251,19 @@ pub fn project_demand(
 }
 
 fn mtp_band_bytes(resident_weight_bytes: u64, mtp_active: bool) -> u64 {
-  if mtp_active {
-    resident_weight_bytes / 6
-  } else {
-    0
-  }
+  if mtp_active { resident_weight_bytes / 6 } else { 0 }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-
   const GIB: u64 = 1024 * 1024 * 1024;
 
-  #[test]
-  fn dir_weight_bytes_follows_links_and_ignores_subdirectories() {
-    let dir = crate::util::test_temp::unique_temp_dir("admission-dir-weight");
-    let blobs = dir.join("blobs");
-    std::fs::create_dir_all(&blobs).expect("blobs");
-    std::fs::write(blobs.join("sha-a"), vec![0u8; 4096]).expect("blob a");
-    std::fs::write(blobs.join("sha-b"), vec![0u8; 2048]).expect("blob b");
-
-    let snapshot = dir.join("snapshot");
-    std::fs::create_dir_all(&snapshot).expect("snapshot");
-    #[cfg(unix)]
-    {
-      std::os::unix::fs::symlink(blobs.join("sha-a"), snapshot.join("a.safetensors"))
-        .expect("link a");
-      std::os::unix::fs::symlink(blobs.join("sha-b"), snapshot.join("b.safetensors"))
-        .expect("link b");
+  fn snap(backend: &str, unified: bool, ram_total: u64, ram_used: u64) -> HostMetricsSnapshot {
+    HostMetricsSnapshot {
+      gpu_backend: backend.to_string(), unified, ram_total_bytes: ram_total, ram_used_bytes: ram_used,
+      ..HostMetricsSnapshot::default()
     }
-    std::fs::create_dir_all(snapshot.join("nested")).expect("nested");
-    std::fs::write(snapshot.join("nested").join("ignored"), vec![0u8; 9999]).expect("ignored");
-
-    #[cfg(unix)]
-    assert_eq!(dir_weight_bytes(&snapshot), 4096 + 2048);
-    assert_eq!(dir_weight_bytes(&dir.join("does-not-exist")), 0);
-    std::fs::remove_dir_all(&dir).ok();
   }
 
   #[test]
@@ -392,12 +277,10 @@ mod tests {
   fn refuses_when_demand_exceeds_free_minus_reservations() {
     let ledger = Ledger::default();
     ledger.try_admit(1, 44 * GIB, 60 * GIB).expect("first admits");
-    let refusal = ledger
-      .try_admit(2, 37 * GIB, 60 * GIB)
-      .expect_err("second must be refused");
+    let refusal = ledger.try_admit(2, 37 * GIB, 60 * GIB).expect_err("second must be refused");
     assert_eq!(refusal.reserved_bytes, 44 * GIB);
     assert_eq!(refusal.available_bytes(), 16 * GIB);
-    assert_eq!(ledger.reserved_bytes(), 44 * GIB, "refusal reserves nothing");
+    assert_eq!(ledger.reserved_bytes(), 44 * GIB);
   }
 
   #[test]
@@ -438,16 +321,6 @@ mod tests {
     assert_eq!(parse_size_bytes(""), None);
   }
 
-  fn snap(backend: &str, unified: bool, ram_total: u64, ram_used: u64) -> HostMetricsSnapshot {
-    HostMetricsSnapshot {
-      gpu_backend: backend.to_string(),
-      unified,
-      ram_total_bytes: ram_total,
-      ram_used_bytes: ram_used,
-      ..HostMetricsSnapshot::default()
-    }
-  }
-
   #[test]
   fn uma_budget_falls_back_to_ram_when_gtt_unknown() {
     let s = snap(HostMetricsSnapshot::BACKEND_AMD, true, 128 * GIB, 28 * GIB);
@@ -479,9 +352,7 @@ mod tests {
     s.uma_shared_used_bytes = Some(2 * GIB);
     assert_eq!(effective_free_bytes_for(&s, true), 94 * GIB);
     let ledger = Ledger::default();
-    assert!(ledger
-      .try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true))
-      .is_ok());
+    assert!(ledger.try_admit(1, 36 * GIB, effective_free_bytes_for(&s, true)).is_ok());
   }
 
   #[test]
@@ -539,25 +410,13 @@ mod tests {
     let knobs = crate::launch::knobs::KnobSet::new();
     let band = overhead_band_bytes(HostMetricsSnapshot::BACKEND_AMD);
     let demand = project_demand(
-      &header,
-      None,
-      &knobs,
-      crate::backend::DEFAULT_BACKEND_ID,
-      16384,
-      HostMetricsSnapshot::BACKEND_AMD,
-      53 * GIB,
-      false,
+      &header, None, &knobs, crate::backend::DEFAULT_BACKEND_ID, 16384,
+      HostMetricsSnapshot::BACKEND_AMD, 53 * GIB, false,
     );
     assert_eq!(demand, 53 * GIB + band);
     let mtp_demand = project_demand(
-      &header,
-      None,
-      &knobs,
-      crate::backend::DEFAULT_BACKEND_ID,
-      16384,
-      HostMetricsSnapshot::BACKEND_AMD,
-      53 * GIB,
-      true,
+      &header, None, &knobs, crate::backend::DEFAULT_BACKEND_ID, 16384,
+      HostMetricsSnapshot::BACKEND_AMD, 53 * GIB, true,
     );
     assert_eq!(mtp_demand, 53 * GIB + band + (53 * GIB / 6));
   }


### PR DESCRIPTION
## Summary

Fix memory admission for AMD UMA GPUs exposed through Linux LXC containers.

On an AMD Ryzen AI Max+ / Radeon 8060S system, llama.cpp/ROCm can see the GPU's full GTT pool (96 GiB in the reported setup), while `/proc/meminfo` inside the LXC reports only the container's configured RAM (8 GiB). The existing UMA admission policy uses `min(ram_free, gtt_free)`, so LlamaStash incorrectly refuses models that fit in the GPU pool.

This PR narrows the exception to:

- Linux LXC
- AMD backend
- unified/UMA GPU
- GTT metrics available

For that combination, admission budgets the AMD GTT pool directly. All other UMA paths retain the existing conservative `min(ram_free, gtt_free)` behavior.

## Why this is safe

The change does not alter llama.cpp placement, `--fit`, headroom calculation, or the reservation ledger. It only changes the admission budget used for the GPU pool in the specific LXC+AMD+UMA case.

The container's RAM limit still applies to CPU-side allocations; the GTT pool is used as the GPU allocation budget. The observed environment validates this distinction: llama.cpp reports ~96 GiB available on the Radeon 8060S, and forcing a 27B Q8 model through the existing gate results in approximately 47 GiB of actual AMD VRAM/GTT usage.

## Implementation

- Add local Linux LXC detection using `/run/systemd/container`, PID 1 environment, and cgroup fallbacks.
- Add a small policy helper so the container-specific behavior is explicit and unit-testable.
- Keep the existing RAM/GTT minimum for bare-metal AMD/Intel UMA, Apple Silicon, other containers, and missing GTT data.

## Tests

Added coverage for:

- AMD UMA in LXC uses GTT instead of the container RAM budget.
- Bare-metal AMD UMA retains the RAM/GTT minimum.
- Non-AMD LXC UMA does not use the GTT-only exception.
- AMD UMA without GTT data still falls back to RAM.

Expected validation in CI: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --features test-fixtures`.